### PR TITLE
Remove extra arg in newLoadBalancer

### DIFF
--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -21,7 +21,7 @@ type kubevipLoadBalancerManager struct {
 	cloudConfigMap string
 }
 
-func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, cm, serviceCidr string) cloudprovider.LoadBalancer {
+func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, cm string) cloudprovider.LoadBalancer {
 	k := &kubevipLoadBalancerManager{
 		kubeClient:     kubeClient,
 		nameSpace:      ns,


### PR DESCRIPTION
I was hitting this when running `make build` on main:
```
...
# github.com/kube-vip/kube-vip-cloud-provider/pkg/provider
pkg/provider/provider.go:83:22: not enough arguments in call to newLoadBalancer
	have (*kubernetes.Clientset, string, string)
	want (*kubernetes.Clientset, string, string, string)
make: *** [Makefile:28: kube-vip-cloud-provider] Error 2
```
`serviceCidr` isn't used in this function so I removed it so `make build` can successfully complete again.