### PR TITLE
Exlude invalid IPs when range crosses the third octet

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -246,7 +246,6 @@ func buildAddressesFromRange(ipRangeString string) ([]string, error) {
 			return nil, fmt.Errorf("unable to parse IP range [%s]", ranges[x])
 		}
 
-
 		firstIP := IPStr2Int(ipRange[0])
 		lastIP := IPStr2Int(ipRange[1])
 		if firstIP > lastIP {
@@ -255,13 +254,23 @@ func buildAddressesFromRange(ipRangeString string) ([]string, error) {
 		}
 
 		for ip := firstIP; ip <= lastIP; ip++ {
-			ips = append(ips, IPInt2Str(ip))
+			if ipInvalid(ip) {
+				ips = append(ips, IPInt2Str(ip))
+			}
 		}
 
 		klog.Infof("Rebuilding addresse cache, [%d] addresses exist", len(ips))
 	}
 	return removeDuplicateAddresses(ips), nil
 	//return ips, nil
+}
+
+func ipInvalid(ip uint) bool {
+	var lastOctet = ip & 0x000000ff
+	if lastOctet == 0x00 || lastOctet == 0xff {
+		return false
+	}
+	return true
 }
 
 func removeDuplicateAddresses(arr []string) []string {

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -21,7 +21,7 @@ type kubevipLoadBalancerManager struct {
 	cloudConfigMap string
 }
 
-func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, cm, serviceCidr string) cloudprovider.LoadBalancer {
+func newLoadBalancer(kubeClient *kubernetes.Clientset, ns, cm string) cloudprovider.LoadBalancer {
 	k := &kubevipLoadBalancerManager{
 		kubeClient:     kubeClient,
 		nameSpace:      ns,


### PR DESCRIPTION
When there is a range that crosses the third octet, there are 2 IPs that shouldn't be used: the ones that end in 255 or 0.
There is also a test that catch this situation and that fails; this PR pass it: "single range, across third octet" in `ipam_test.go`.