### PR TITLE
Embed logic for DHCP workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The `kube-vip-cloud-provider` will only implement the `loadBalancer` functionali
 - Multiple pools by CIDR per namespace
 - Multiple IP ranges per namespace (handles overlapping ranges)
 - Setting of static addresses through `--load-balancer-ip=x.x.x.x`
+- Setting the special IP `0.0.0.0` for DHCP workflow.
 
 ## Installing the `kube-vip-cloud-provider`
 
@@ -68,6 +69,10 @@ kubectl create configmap --namespace kube-system kubevip --from-literal range-gl
 ## Multiple pools or ranges
 
 We can apply multiple pools or ranges by seperating them with commas.. i.e. `192.168.0.200/30,192.168.0.200/29` or `192.168.0.10-192.168.0.11,192.168.0.10-192.168.0.13`
+
+## Special DHCP CIDR
+
+Set the CIDR to `0.0.0.0/32`, that will make the controller to give all _LoadBalancers_ the IP `0.0.0.0`.
 
 ## Debugging
 

--- a/pkg/ipam/addressbuilder.go
+++ b/pkg/ipam/addressbuilder.go
@@ -52,7 +52,7 @@ func IPStr2Int(ip string) uint {
 	return uint(b[3]) | uint(b[2])<<8 | uint(b[1])<<16 | uint(b[0])<<24
 }
 
-//IPInt2Str - Converts the IP address in integer format to an string
+// IPInt2Str - Converts the IP address in integer format to an string
 func IPInt2Str(i uint) string {
 	ip := make(net.IP, net.IPv4len)
 	ip[0] = byte(i >> 24)

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/klog"
 )
 
-//kubevipLoadBalancerManager -
+// kubevipLoadBalancerManager -
 type kubevipLoadBalancerManager struct {
 	kubeClient     *kubernetes.Clientset
 	nameSpace      string
@@ -60,7 +60,7 @@ func getDefaultLoadBalancerName(service *v1.Service) string {
 	return cloudprovider.DefaultLoadBalancerName(service)
 }
 
-//nolint
+// nolint
 func (k *kubevipLoadBalancerManager) deleteLoadBalancer(ctx context.Context, service *v1.Service) error {
 	klog.Infof("deleting service '%s' (%s)", service.Name, service.UID)
 
@@ -200,8 +200,11 @@ func discoverPool(cm *v1.ConfigMap, namespace, configMapName string) (pool strin
 }
 
 func discoverAddress(namespace, pool string, existingServiceIPS []string) (vip string, err error) {
+	// Check if DHCP is required
+	if pool == "0.0.0.0/32" {
+		vip = "0.0.0.0"
 	// Check if ip pool contains a cidr, if not assume it is a range
-	if strings.Contains(pool, "/") {
+	} else if strings.Contains(pool, "/") {
 		vip, err = ipam.FindAvailableHostFromCidr(namespace, pool, existingServiceIPS)
 		if err != nil {
 			return "", err

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -68,7 +68,7 @@ func Test_DiscoveryPoolRange(t *testing.T) {
 		data    v1.ConfigMap
 		ipRange string
 	}
-	
+
 	dummy := new(v1.ConfigMap)
 	dummy.Data = map[string]string{}
 	dummy.Data["range-dummystart"] = "172.16.0.1-172.16.0.254"


### PR DESCRIPTION
This pull request adds the logic to handle the special DHCP workflow with `0.0.0.0` by setting the CIDR to `0.0.0.0/32`. It will give all _LoadBalancers_ the same IP.