### PR TITLE
Change kvcp from statefulset to deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kube-vip-cloud-provider
 
-The [Kube-Vip](https://kube-vip.io) cloud provider is a general purpose cloud-provider for on-prem bare-metal or virtualised environments. It's designed to work with the [kube-vip](https://kube-vip.io) project however if a load-balancer solution follows the [Kubernetes](https://kubernetes.io) conventions then this cloud-provider will provide IP addresses that another solution can advertise. 
+The [Kube-Vip](https://kube-vip.io) cloud provider is a general purpose cloud-provider for on-prem bare-metal or virtualised environments. It's designed to work with the [kube-vip](https://kube-vip.io) project however if a load-balancer solution follows the [Kubernetes](https://kubernetes.io) conventions then this cloud-provider will provide IP addresses that another solution can advertise.
 
 ## Architecture
 
@@ -22,17 +22,19 @@ We can apply the controller manifest directly from this repository to get the la
 $ kubectl apply -f https://raw.githubusercontent.com/kube-vip/kube-vip-cloud-provider/main/manifest/kube-vip-cloud-controller.yaml
 ```
 
-It uses a `statefulSet` and can always be viewed with the following command:
+It uses a `Deployment` and can always be viewed with the following command:
 
 ```
-kubectl describe pods -n kube-system kube-vip-cloud-provider-0
+kubectl describe deployment/kube-vip-cloud-provider -n kube-system
+POD_NAME=$(kubectl get po -n kube-system | grep kube-vip-cloud-provider | cut -d' ' -f1)
+kubectl describe pod/$POD_NAME -n kube-system
 ```
 
 ## Global and namespace pools
 
 ### Global pool
 
-Any service in any namespace will take an address from the global pool `cidr/range`-global. 
+Any service in any namespace will take an address from the global pool `cidr/range`-global.
 
 ### Namespace pool
 

--- a/manifest/kube-vip-cloud-controller.yaml
+++ b/manifest/kube-vip-cloud-controller.yaml
@@ -35,19 +35,22 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: kube-vip-cloud-provider
   namespace: kube-system
 spec:
-  serviceName: kube-vip-cloud-provider
-  podManagementPolicy: OrderedReady
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: kube-vip
       component: kube-vip-cloud-provider
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -61,10 +64,25 @@ spec:
         image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.3
         name: kube-vip-cloud-provider
         imagePullPolicy: Always
-        resources: {}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 30
       serviceAccountName: kube-vip-cloud-controller
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists


### PR DESCRIPTION
# Context
Change kvcp from statefulset to deployment
Fix #https://github.com/kube-vip/kube-vip-cloud-provider/issues/45

# Related changes
* Change readme
* Add upgrade strategy to deployment
* Add tolerations and affinity rules to allow deploying kube-vip-cloud-provider on control plane 



