### PR TITLE
Fix name of legacy label, update image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TARGET := kube-vip-cloud-provider
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.0.2
+VERSION := v0.0.4
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -233,13 +233,14 @@ func Test_syncLoadBalancer(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name: "add new annotation to legacy service which already has spec.loadbalancerIP",
+			name: "add new annotation to legacy service which already has spec.loadbalancerIP, remove legacy label",
 			originalService: v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "name",
 					Labels: map[string]string{
 						"implementation": "kube-vip",
+						"ipam-address":   "192.168.1.1",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -327,7 +328,7 @@ func Test_syncLoadBalancer(t *testing.T) {
 			}
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("discoverAddress() error: %v, expected: %v", err, tt.wantErr)
+				t.Errorf("syncLoadBalancer() error: %v, expected: %v", err, tt.wantErr)
 				return
 			}
 


### PR DESCRIPTION
In PR https://github.com/kube-vip/kube-vip-cloud-provider/pull/52, we deprecated loadbalancerIP and old label.
This one is to fix the label name.
Also update default image tag in MakeFile
