### PR TITLE
IPV6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The `kube-vip-cloud-provider` will only implement the `loadBalancer` functionali
 - IP ranges [start address - end address]
 - Multiple pools by CIDR per namespace
 - Multiple IP ranges per namespace (handles overlapping ranges)
-- Setting of static addresses through `--load-balancer-ip=x.x.x.x`
+- Setting of static addresses through `--load-balancer-ip=x.x.x.x` or through annotations `kube-vip.io/loadbalancerIPs: x.x.x.x`
 - Setting the special IP `0.0.0.0` for DHCP workflow.
+- Support single stack IPv6 or IPv4
 
 ## Installing the `kube-vip-cloud-provider`
 
@@ -56,6 +57,7 @@ data:
   cidr-development: 192.168.0.210/29
   cidr-finance: 192.168.0.220/29
   cidr-testing: 192.168.0.230/29
+  cidr-ipv6: 2001::10/127
 ```
 
 ## Create an IP pool using a CIDR
@@ -72,7 +74,7 @@ kubectl create configmap --namespace kube-system kubevip --from-literal range-gl
 
 ## Multiple pools or ranges
 
-We can apply multiple pools or ranges by seperating them with commas.. i.e. `192.168.0.200/30,192.168.0.200/29` or `192.168.0.10-192.168.0.11,192.168.0.10-192.168.0.13`
+We can apply multiple pools or ranges by seperating them with commas.. i.e. `192.168.0.200/30,192.168.0.200/29` or `2001::12/127,2001::10/127` or `192.168.0.10-192.168.0.11,192.168.0.10-192.168.0.13` or `2001::10-2001::14,2001::20-2001::24`
 
 ## Special DHCP CIDR
 

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
+	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0 h1:mZQZefskPPCMIBCSEH0v2/iUqqLrYtaeqwD6FUGUnFE=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
+go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35 h1:nJAwRlGWZZDOD+6wni9KVUNHMpHko/OnRwsrCYeAzPo=
+go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35/go.mod h1:TQvodOM+hJTioNQJilmLXu08JNb8i+ccq418+KWu1/Y=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/pkg/ipam/addressbuilder.go
+++ b/pkg/ipam/addressbuilder.go
@@ -2,69 +2,34 @@ package ipam
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 
-	"k8s.io/klog"
+	"go4.org/netipx"
 )
 
-// buildHostsFromCidr - Builds a list of addresses in the cidr
-func buildHostsFromCidr(cidr string) ([]string, error) {
-	var ips []string
-
+// buildHostsFromCidr - Builds a IPSet constructed from the cidr
+func buildHostsFromCidr(cidr string) (*netipx.IPSet, error) {
 	// Split the ipranges (comma separated)
 	cidrs := strings.Split(cidr, ",")
 	if len(cidrs) == 0 {
 		return nil, fmt.Errorf("unable to parse IP cidrs [%s]", cidr)
 	}
 
-	for x := range cidrs {
+	builder := &netipx.IPSetBuilder{}
 
-		ip, ipnet, err := net.ParseCIDR(cidrs[x])
+	for x := range cidrs {
+		prefix, err := netip.ParsePrefix(cidrs[x])
 		if err != nil {
 			return nil, err
 		}
-
-		var cidrips []string
-		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
-			cidrips = append(cidrips, ip.String())
-		}
-
-		// remove network address and broadcast address
-		lenIPs := len(cidrips)
-		switch {
-		case lenIPs < 2:
-			ips = append(ips, cidrips...)
-
-		default:
-			ips = append(ips, cidrips[1:len(cidrips)-1]...)
-		}
+		builder.AddPrefix(prefix)
 	}
-	return removeDuplicateAddresses(ips), nil
+	return builder.IPSet()
 }
 
-// IPStr2Int - Converts the IP address in string format to an integer
-func IPStr2Int(ip string) uint {
-	b := net.ParseIP(ip).To4()
-	if b == nil {
-		return 0
-	}
-	return uint(b[3]) | uint(b[2])<<8 | uint(b[1])<<16 | uint(b[0])<<24
-}
-
-// IPInt2Str - Converts the IP address in integer format to an string
-func IPInt2Str(i uint) string {
-	ip := make(net.IP, net.IPv4len)
-	ip[0] = byte(i >> 24)
-	ip[1] = byte(i >> 16)
-	ip[2] = byte(i >> 8)
-	ip[3] = byte(i)
-	return ip.String()
-}
-
-// buildHostsFromRange - Builds a list of addresses in the cidr
-func buildAddressesFromRange(ipRangeString string) ([]string, error) {
-	var ips []string
+// buildHostsFromRange - Builds a IPSet constructed from the Range
+func buildAddressesFromRange(ipRangeString string) (*netipx.IPSet, error) {
 	// Split the ipranges (comma separated)
 
 	ranges := strings.Split(ipRangeString, ",")
@@ -72,61 +37,26 @@ func buildAddressesFromRange(ipRangeString string) ([]string, error) {
 		return nil, fmt.Errorf("unable to parse IP ranges [%s]", ipRangeString)
 	}
 
+	builder := &netipx.IPSetBuilder{}
+
 	for x := range ranges {
 		ipRange := strings.Split(ranges[x], "-")
-		// Make sure we have x.x.x.x-x.x.x.x
+		// Make sure we have x.x.x.x-x.x.x.x or x:x:x:x:x:x:x:x:x-x:x:x:x:x:x:x:x:x
 		if len(ipRange) != 2 {
 			return nil, fmt.Errorf("unable to parse IP range [%s]", ranges[x])
 		}
 
-		firstIP := IPStr2Int(ipRange[0])
-		lastIP := IPStr2Int(ipRange[1])
-		if firstIP > lastIP {
-			// swap
-			firstIP, lastIP = lastIP, firstIP
+		start, err := netip.ParseAddr(ipRange[0])
+		if err != nil {
+			return nil, err
+		}
+		end, err := netip.ParseAddr(ipRange[1])
+		if err != nil {
+			return nil, err
 		}
 
-		for ip := firstIP; ip <= lastIP; ip++ {
-			if ipInvalid(ip) {
-				ips = append(ips, IPInt2Str(ip))
-			}
-		}
-
-		klog.Infof("Rebuilding addresse cache, [%d] addresses exist", len(ips))
+		builder.AddRange(netipx.IPRangeFrom(start, end))
 	}
-	return removeDuplicateAddresses(ips), nil
-	//return ips, nil
-}
 
-func ipInvalid(ip uint) bool {
-	var lastOctet = ip & 0x000000ff
-	if lastOctet == 0x00 || lastOctet == 0xff {
-		return false
-	}
-	return true
-}
-
-func removeDuplicateAddresses(arr []string) []string {
-	addresses := map[string]bool{}
-	uniqueAddresses := []string{} // Keep all keys from the map into a slice.
-
-	// iterate over all addresses from range, add them to a map if not found
-	// then add them to the unique addresses afterwards
-	for i := range arr {
-		if !addresses[arr[i]] {
-			addresses[arr[i]] = true
-			uniqueAddresses = append(uniqueAddresses, arr[i])
-
-		}
-	}
-	return uniqueAddresses
-}
-
-func inc(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
-	}
+	return builder.IPSet()
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -1,9 +1,11 @@
 package ipam
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go4.org/netipx"
 )
 
 func Test_buildHostsFromRange(t *testing.T) {
@@ -127,35 +129,144 @@ func TestFindAvailableHostFromRange(t *testing.T) {
 		{
 			name: "simple range",
 			args: args{
-				namespace:        "default2",
-				ipRange:          "192.168.0.10-192.168.0.11",
-				existingServices: []string{""},
+				namespace:        "default",
+				ipRange:          "192.168.0.10-192.168.0.10",
+				existingServices: []string{},
 			},
 			want: "192.168.0.10",
 		},
 		{
-			name: "simple range",
+			name: "single range, three addresses",
 			args: args{
 				namespace:        "default2",
-				ipRange:          "192.168.0.10-192.168.0.11",
-				existingServices: []string{""},
+				ipRange:          "192.168.0.10-192.168.0.12",
+				existingServices: []string{},
 			},
 			want: "192.168.0.10",
 		},
+		{
+			name: "single range, across third octet",
+			args: args{
+				namespace:        "default2",
+				ipRange:          "192.168.0.253-192.168.1.2",
+				existingServices: []string{"192.168.0.253", "192.168.0.254"},
+			},
+			want: "192.168.1.1",
+		},
+		{
+			name: "two ranges, four addresses",
+			args: args{
+				namespace:        "default2",
+				ipRange:          "192.168.0.10-192.168.0.11,192.168.1.20-192.168.1.21",
+				existingServices: []string{"192.168.0.9", "192.168.0.10"},
+			},
+			want: "192.168.0.11",
+		},
 	}
-	// Manager = append(Manager, ipManager{
-	// 	ipRange:   "192.168.0.10-192.168.0.11",
-	// 	namespace: "default",
-	// })
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FindAvailableHostFromRange(tt.args.namespace, tt.args.ipRange, tt.args.existingServices)
+			builder := &netipx.IPSetBuilder{}
+			for i := range tt.args.existingServices {
+				addr, err := netip.ParseAddr(tt.args.existingServices[i])
+				if err != nil {
+					t.Errorf("FindAvailableHostFromRange() error = %v", err)
+					return
+				}
+				builder.Add(addr)
+			}
+			s, err := builder.IPSet()
+			if err != nil {
+				t.Errorf("FindAvailableHostFromRange() error = %v", err)
+				return
+			}
+
+			got, err := FindAvailableHostFromRange(tt.args.namespace, tt.args.ipRange, s)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FindAvailableHostFromRange() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
 				t.Errorf("FindAvailableHostFromRange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindAvailableHostFromCIDR(t *testing.T) {
+	type args struct {
+		namespace        string
+		cidr             string
+		existingServices []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single entry, two address",
+			args: args{
+				namespace:        "default",
+				cidr:             "192.168.0.200/30",
+				existingServices: []string{},
+			},
+			want: "192.168.0.200",
+		},
+		{
+			name: "simple cidr, cidr contains .0 and .255",
+			args: args{
+				namespace:        "default2",
+				cidr:             "192.168.0.10/24",
+				existingServices: []string{},
+			},
+			want: "192.168.0.1",
+		},
+		{
+			name: "no ip available",
+			args: args{
+				namespace:        "default2",
+				cidr:             "192.168.0.255/30",
+				existingServices: []string{"192.168.0.254", "192.168.0.252", "192.168.0.253"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dual entry, overlap address",
+			args: args{
+				namespace:        "default2",
+				cidr:             "192.168.0.200/30,192.168.0.200/29",
+				existingServices: []string{"192.168.0.9", "192.168.0.10"},
+			},
+			want: "192.168.0.200",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &netipx.IPSetBuilder{}
+			for i := range tt.args.existingServices {
+				addr, err := netip.ParseAddr(tt.args.existingServices[i])
+				if err != nil {
+					t.Errorf("FindAvailableHostFromCIDR() error = %v", err)
+					return
+				}
+				builder.Add(addr)
+			}
+			s, err := builder.IPSet()
+			if err != nil {
+				t.Errorf("FindAvailableHostFromCIDR() error = %v", err)
+				return
+			}
+
+			got, err := FindAvailableHostFromCidr(tt.args.namespace, tt.args.cidr, s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindAvailableHostFromCIDR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FindAvailableHostFromCIDR() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -4,7 +4,6 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"go4.org/netipx"
 )
 
@@ -39,7 +38,7 @@ func Test_buildHostsFromRange(t *testing.T) {
 			args: args{
 				"192.168.0.253-192.168.1.2",
 			},
-			want:    []string{"192.168.0.253", "192.168.0.254", "192.168.1.1", "192.168.1.2"},
+			want:    []string{"192.168.0.253", "192.168.0.254", "192.168.0.255", "192.168.1.0", "192.168.1.1", "192.168.1.2"},
 			wantErr: false,
 		},
 		{
@@ -58,6 +57,38 @@ func Test_buildHostsFromRange(t *testing.T) {
 			want:    []string{"192.168.0.10", "192.168.0.11", "192.168.0.12", "192.168.0.13"},
 			wantErr: false,
 		},
+		{
+			name: "ipv6, two ips",
+			args: args{
+				"fe80::13-fe80::14",
+			},
+			want:    []string{"fe80::13", "fe80::14"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, single range, across third octet",
+			args: args{
+				"fe80::ffff-fe80::1:3",
+			},
+			want:    []string{"fe80::ffff", "fe80::1:0", "fe80::1:1", "fe80::1:2", "fe80::1:3"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, two ranges, 5 addresses",
+			args: args{
+				"fe80::10-fe80::12,fe81::13-fe81::14",
+			},
+			want:    []string{"fe80::10", "fe80::11", "fe80::12", "fe81::13", "fe81::14"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, two ranges, 5 addresses w/overlap",
+			args: args{
+				"fe80::10-fe80::12,fe80::10-fe80::14",
+			},
+			want:    []string{"fe80::10", "fe80::11", "fe80::12", "fe80::13", "fe80::14"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -66,8 +97,24 @@ func Test_buildHostsFromRange(t *testing.T) {
 				t.Errorf("buildHostsFromRange() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !assert.ElementsMatch(t, got, tt.want) {
-				t.Errorf("buildHostsFromRange() = %v, want %v", got, tt.want)
+
+			builder := &netipx.IPSetBuilder{}
+			for i := range tt.want {
+				addr, err := netip.ParseAddr(tt.want[i])
+				if err != nil {
+					t.Errorf("buildAddressesFromRange() error = %v", err)
+					return
+				}
+				builder.Add(addr)
+			}
+			s, err := builder.IPSet()
+			if err != nil {
+				t.Errorf("buildAddressesFromRange() error = %v", err)
+				return
+			}
+
+			if !got.Equal(s) {
+				t.Errorf("buildHostsFromRange() = %v, want %v", got.Prefixes(), tt.want)
 			}
 		})
 	}
@@ -84,11 +131,11 @@ func Test_buildHostsFromCidr(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "single entry, two address",
+			name: "single entry, 4 address",
 			args: args{
 				"192.168.0.200/30",
 			},
-			want:    []string{"192.168.0.201", "192.168.0.202"},
+			want:    []string{"192.168.0.200", "192.168.0.201", "192.168.0.202", "192.168.0.203"},
 			wantErr: false,
 		},
 		{
@@ -96,7 +143,31 @@ func Test_buildHostsFromCidr(t *testing.T) {
 			args: args{
 				"192.168.0.200/30,192.168.0.200/29",
 			},
-			want:    []string{"192.168.0.201", "192.168.0.202", "192.168.0.203", "192.168.0.204", "192.168.0.205", "192.168.0.206"},
+			want:    []string{"192.168.0.200", "192.168.0.201", "192.168.0.202", "192.168.0.203", "192.168.0.204", "192.168.0.205", "192.168.0.206", "192.168.0.207"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, two ips",
+			args: args{
+				"fe80::10/127",
+			},
+			want:    []string{"fe80::10", "fe80::11"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, two cidrs",
+			args: args{
+				"fe80::10/127,fe80::fe/127",
+			},
+			want:    []string{"fe80::10", "fe80::11", "fe80::fe", "fe80::ff"},
+			wantErr: false,
+		},
+		{
+			name: "ipv6, two cidrs with overlap",
+			args: args{
+				"fe80::10/126,fe80::12/127",
+			},
+			want:    []string{"fe80::10", "fe80::11", "fe80::12", "fe80::13"},
 			wantErr: false,
 		},
 	}
@@ -107,8 +178,24 @@ func Test_buildHostsFromCidr(t *testing.T) {
 				t.Errorf("buildHostsFromCidr() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !assert.ElementsMatch(t, got, tt.want) {
-				t.Errorf("buildHostsFromCidr() = %v, want %v", got, tt.want)
+
+			builder := &netipx.IPSetBuilder{}
+			for i := range tt.want {
+				addr, err := netip.ParseAddr(tt.want[i])
+				if err != nil {
+					t.Errorf("buildAddressesFromRange() error = %v", err)
+					return
+				}
+				builder.Add(addr)
+			}
+			s, err := builder.IPSet()
+			if err != nil {
+				t.Errorf("buildHostsFromCidr() error = %v", err)
+				return
+			}
+
+			if !got.Equal(s) {
+				t.Errorf("buildHostsFromCidr() = %v, want %v", got.Ranges(), tt.want)
 			}
 		})
 	}
@@ -161,6 +248,42 @@ func TestFindAvailableHostFromRange(t *testing.T) {
 				existingServices: []string{"192.168.0.9", "192.168.0.10"},
 			},
 			want: "192.168.0.11",
+		},
+		{
+			name: "ipv6, simple range",
+			args: args{
+				namespace:        "default",
+				ipRange:          "fe80::13-fe80::14",
+				existingServices: []string{},
+			},
+			want: "fe80::13",
+		},
+		{
+			name: "single range, three addresses",
+			args: args{
+				namespace:        "default2",
+				ipRange:          "fe80::13-fe80::15",
+				existingServices: []string{},
+			},
+			want: "fe80::13",
+		},
+		{
+			name: "single range, across third octet",
+			args: args{
+				namespace:        "default2",
+				ipRange:          "fe80::ffff-fe80::1:3",
+				existingServices: []string{"fe80::1:0"},
+			},
+			want: "fe80::ffff",
+		},
+		{
+			name: "two ranges, 5 addresses",
+			args: args{
+				namespace:        "default2",
+				ipRange:          "fe80::10-fe80::12,fe81::20-fe81::21",
+				existingServices: []string{"fe80::10", "fe80::11", "fe80::12"},
+			},
+			want: "fe81::20",
 		},
 	}
 
@@ -237,9 +360,36 @@ func TestFindAvailableHostFromCIDR(t *testing.T) {
 			args: args{
 				namespace:        "default2",
 				cidr:             "192.168.0.200/30,192.168.0.200/29",
-				existingServices: []string{"192.168.0.9", "192.168.0.10"},
+				existingServices: []string{"192.168.0.201", "192.168.0.202"},
 			},
 			want: "192.168.0.200",
+		},
+		{
+			name: "ipv6, single entry, two address",
+			args: args{
+				namespace:        "default",
+				cidr:             "2001::49fe/127",
+				existingServices: []string{},
+			},
+			want: "2001::49fe",
+		},
+		{
+			name: "no ip available",
+			args: args{
+				namespace:        "default2",
+				cidr:             "2001::49fe/127",
+				existingServices: []string{"2001::49fe", "2001::49ff"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dual entry, overlap address",
+			args: args{
+				namespace:        "default2",
+				cidr:             "2001::10/126,2001::12/127",
+				existingServices: []string{"2001::10", "2001::11"},
+			},
+			want: "2001::12",
 		},
 	}
 

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strings"
 
 	"github.com/kube-vip/kube-vip-cloud-provider/pkg/ipam"
+	"go4.org/netipx"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -148,13 +150,17 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 		}
 	}
 
-	var existingServiceIPS []string
+	builder := &netipx.IPSetBuilder{}
 	for x := range svcs.Items {
-		existingServiceIPS = append(existingServiceIPS, svcs.Items[x].Annotations[loadbalancerIPsAnnotations])
+		addr, err := netip.ParseAddr(svcs.Items[x].Annotations[loadbalancerIPsAnnotations])
+		if err != nil {
+			return nil, err
+		}
+		builder.Add(addr)
 	}
 
 	// If the LoadBalancer address is empty, then do a local IPAM lookup
-	loadBalancerIP, err := discoverAddress(service.Namespace, pool, existingServiceIPS)
+	loadBalancerIP, err := discoverAddress(service.Namespace, pool, builder.IPSet())
 
 	if err != nil {
 		return nil, err
@@ -238,18 +244,18 @@ func discoverPool(cm *v1.ConfigMap, namespace, configMapName string) (pool strin
 	return "", false, fmt.Errorf("no address pools could be found")
 }
 
-func discoverAddress(namespace, pool string, existingServiceIPS []string) (vip string, err error) {
+func discoverAddress(namespace, pool string, inUseIPSet *netipx.IPSet) (vip string, err error) {
 	// Check if DHCP is required
 	if pool == "0.0.0.0/32" {
 		vip = "0.0.0.0"
 		// Check if ip pool contains a cidr, if not assume it is a range
 	} else if strings.Contains(pool, "/") {
-		vip, err = ipam.FindAvailableHostFromCidr(namespace, pool, existingServiceIPS)
+		vip, err = ipam.FindAvailableHostFromCidr(namespace, pool, inUseIPSet)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		vip, err = ipam.FindAvailableHostFromRange(namespace, pool, existingServiceIPS)
+		vip, err = ipam.FindAvailableHostFromRange(namespace, pool, inUseIPSet)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -158,9 +158,13 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 		}
 		builder.Add(addr)
 	}
+	inUseSet, err := builder.IPSet()
+	if err != nil {
+		return nil, err
+	}
 
 	// If the LoadBalancer address is empty, then do a local IPAM lookup
-	loadBalancerIP, err := discoverAddress(service.Namespace, pool, builder.IPSet())
+	loadBalancerIP, err := discoverAddress(service.Namespace, pool, inUseSet)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Add IPV6 ipam function
* Refactor ipam logic using library go4.org/netipx. Previously the logic to check each ip in the range is not suitable for ipv6 address since there are so many.
* Now of ipv4 address, only skip `.0` and `.255`. Doesn't skip ipv6 address
* More unit test