### PR TITLE
LoadbalancerClass support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ The `kube-vip-cloud-provider` will only implement the `loadBalancer` functionali
 
 ## IP address functionality
 
-- IP address pools by CIDR
-- IP ranges [start address - end address]
-- Multiple pools by CIDR per namespace
-- Multiple IP ranges per namespace (handles overlapping ranges)
-- Setting of static addresses through `--load-balancer-ip=x.x.x.x` or through annotations `kube-vip.io/loadbalancerIPs: x.x.x.x`
+- IP address pools by CIDR.
+- IP ranges [start address - end address].
+- Multiple pools by CIDR per namespace.
+- Multiple IP ranges per namespace (handles overlapping ranges).
+- Setting of static addresses through `--load-balancer-ip=x.x.x.x` or through annotations `kube-vip.io/loadbalancerIPs: x.x.x.x`.
 - Setting the special IP `0.0.0.0` for DHCP workflow.
-- Support single stack IPv6 or IPv4
+- Support single stack IPv6 or IPv4.
+- Support loadbalancerClass `kube-vip.io/kube-vip-class` or custom loadbalancerClass name.
 
 ## Installing the `kube-vip-cloud-provider`
 
@@ -79,6 +80,12 @@ We can apply multiple pools or ranges by seperating them with commas.. i.e. `192
 ## Special DHCP CIDR
 
 Set the CIDR to `0.0.0.0/32`, that will make the controller to give all _LoadBalancers_ the IP `0.0.0.0`.
+
+## LoadbalancerClass support
+
+If users only want kube-vip-cloud-provider to allocate ip for specific set of services, they can pass `KUBEVIP_ENABLE_LOADBALANCERCLASS: true` as an environment variable to kube-vip-cloud-provider. kube-vip-cloud-provider will only allocate ip to service with `spec.loadBalancerClass: kube-vip.io/kube-vip-class`.
+
+If users want to use a custom loadbalancerClass name, they can pass `KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME: <custom name>` as an environment variable, without setting `KUBEVIP_ENABLE_LOADBALANCERCLASS`. They set `spec.loadBalancerClass: <custom name>` on the service.
 
 ## Debugging
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 
 	cloudprovider "k8s.io/cloud-provider"
 )
@@ -106,6 +107,11 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 			return nil, fmt.Errorf("error creating kubernetes client: %s", err.Error())
 		}
 	}
+
+	if lbClass != "" {
+		klog.Infof("kube-vip-cloud-provider starts with loadbalancerClass setting: '%s'. It will only allocate IPs for services with this loadbalancerClass", lbClass)
+	}
+
 	return &KubeVipCloudProvider{
 		lb: newLoadBalancer(cl, ns, cm, lbClass),
 	}, nil


### PR DESCRIPTION
Fix https://github.com/kube-vip/kube-vip-cloud-provider/issues/61
* kube-vip-cloud-provider can allocate ip to service only set with kube-vip loadbalancerclass `kube-vip.io/kube-vip-class`, by passing `KUBEVIP_ENABLE_LOADBALANCERCLASS` env variable to kube-vip-cloud-provider
* User can also set custom loadbalancerclass name through env variable `KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME`, User can set `KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME` without setting `KUBEVIP_ENABLE_LOADBALANCERCLASS`

Conditions
1. If service has loadbalancerClass, kube-vip-cloud-provider is **not** configured with loadbalancerClass, kube-vip-cloud-provider will ignore the service
2. If service **doesn't** have loadbalancerClass, kube-vip-cloud-provider is configured with loadbalancerClass, kube-vip-
cloud-provider will ignore the service 
3. If service has loadbalancerClass, kube-vip-cloud-provider is configured with loadbalancerClass, kube-vip-
cloud-provider will allocate ip for the service
4. If service **doesn't** have loadbalancerClass, kube-vip-cloud-provider is **not** configured with loadbalancerClass, kube-vip-
cloud-provider will allocate ip for the service