### PR TITLE
Support for dualstack loadbalancer services

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ The `kube-vip-cloud-provider` will only implement the `loadBalancer` functionali
 - IP ranges [start address - end address]
 - Multiple pools by CIDR per namespace
 - Multiple IP ranges per namespace (handles overlapping ranges)
+- Support for mixed IP families when specifying multiple pools or ranges
 - Setting of static addresses through `--load-balancer-ip=x.x.x.x` or through annotations `kube-vip.io/loadbalancerIPs: x.x.x.x`
 - Setting the special IP `0.0.0.0` for DHCP workflow.
 - Support single stack IPv6 or IPv4
+- Support for dualstack via the annotation: `kube-vip.io/loadbalancerIPs: 192.168.10.10,2001:db8::1`
 - Support ascending and descending search order by setting search-order=desc
 
 ## Installing the `kube-vip-cloud-provider`
@@ -87,7 +89,8 @@ kubectl create configmap --namespace kube-system kubevip --from-literal range-gl
 
 ## Multiple pools or ranges
 
-We can apply multiple pools or ranges by seperating them with commas.. i.e. `192.168.0.200/30,192.168.0.200/29` or `2001::12/127,2001::10/127` or `192.168.0.10-192.168.0.11,192.168.0.10-192.168.0.13` or `2001::10-2001::14,2001::20-2001::24`
+We can apply multiple pools or ranges by seperating them with commas.. i.e. `192.168.0.200/30,192.168.0.200/29` or `2001::12/127,2001::10/127` or `192.168.0.10-192.168.0.11,192.168.0.10-192.168.0.13` or `2001::10-2001::14,2001::20-2001::24` or `192.168.0.200/30,2001::10/127`
+
 
 ## Special DHCP CIDR
 

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -20,7 +20,7 @@ import (
 const (
 	// this annotation is for specifying IPs for a loadbalancer
 	// use plural for dual stack support in the future
-	// Example: kube-vip.io/loadbalancerIPs: 10.1.2.3
+	// Example: kube-vip.io/loadbalancerIPs: 10.1.2.3,fd00::100
 	loadbalancerIPsAnnotations = "kube-vip.io/loadbalancerIPs"
 	implementationLabelKey     = "implementation"
 	implementationLabelValue   = "kube-vip"
@@ -192,8 +192,7 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 	descOrder := getSearchOrder(controllerCM)
 
 	// If the LoadBalancer address is empty, then do a local IPAM lookup
-	loadBalancerIP, err := discoverAddress(service.Namespace, pool, inUseSet, descOrder)
-
+	loadBalancerIPs, err := discoverVIPs(service.Namespace, pool, inUseSet, descOrder, service.Spec.IPFamilyPolicy, service.Spec.IPFamilies)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +204,7 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 			return getErr
 		}
 
-		klog.Infof("Updating service [%s], with load balancer IPAM address [%s]", service.Name, loadBalancerIP)
+		klog.Infof("Updating service [%s], with load balancer IPAM address(es) [%s]", service.Name, loadBalancerIPs)
 
 		if recentService.Labels == nil {
 			// Just because ..
@@ -218,11 +217,11 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 			recentService.Annotations = make(map[string]string)
 		}
 		// use annotation instead of label to support ipv6
-		recentService.Annotations[loadbalancerIPsAnnotations] = loadBalancerIP
+		recentService.Annotations[loadbalancerIPsAnnotations] = loadBalancerIPs
 
 		// this line will be removed once kube-vip can recognize annotations
 		// Set IPAM address to Load Balancer Service
-		recentService.Spec.LoadBalancerIP = loadBalancerIP
+		recentService.Spec.LoadBalancerIP = strings.Split(loadBalancerIPs, ",")[0]
 
 		// Update the actual service with the address and the labels
 		_, updateErr := k.kubeClient.CoreV1().Services(recentService.Namespace).Update(ctx, recentService, metav1.UpdateOptions{})
@@ -274,6 +273,81 @@ func discoverPool(cm *v1.ConfigMap, namespace, configMapName string) (pool strin
 	}
 
 	return "", false, fmt.Errorf("no address pools could be found")
+}
+
+func discoverVIPs(
+	namespace, pool string, inUseIPSet *netipx.IPSet, descOrder bool,
+	ipFamilyPolicy *v1.IPFamilyPolicy, ipFamilies []v1.IPFamily,
+) (vips string, err error) {
+	var ipv4Pool, ipv6Pool string
+
+	// Check if DHCP is required
+	if pool == "0.0.0.0/32" {
+		return "0.0.0.0", nil
+		// Check if ip pool contains a cidr, if not assume it is a range
+	} else if len(pool) == 0 {
+		return "", fmt.Errorf("could not discover address: pool is not specified")
+	} else if strings.Contains(pool, "/") {
+		ipv4Pool, ipv6Pool, err = ipam.SplitCIDRsByIPFamily(pool)
+	} else {
+		ipv4Pool, ipv6Pool, err = ipam.SplitRangesByIPFamily(pool)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	vipBuilder := strings.Builder{}
+
+	// Handle single stack case
+	if ipFamilyPolicy == nil || *ipFamilyPolicy == v1.IPFamilyPolicySingleStack {
+		ipPool := ipv4Pool
+		if len(ipFamilies) == 0 {
+			if len(ipv4Pool) == 0 {
+				ipPool = ipv6Pool
+			}
+		} else if ipFamilies[0] == v1.IPv6Protocol {
+			ipPool = ipv6Pool
+		}
+		if len(ipPool) == 0 {
+			return "", fmt.Errorf("could not find suitable pool for the IP family of the service")
+		}
+		return discoverAddress(namespace, ipPool, inUseIPSet, descOrder)
+	}
+
+	// Handle dual stack case
+	if *ipFamilyPolicy == v1.IPFamilyPolicyRequireDualStack {
+		// With RequireDualStack, we want to make sure both pools with both IP
+		// families exist
+		if len(ipv4Pool) == 0 || len(ipv6Pool) == 0 {
+			return "", fmt.Errorf("service requires dual-stack, but the configuration does not have both IPv4 and IPv6 pools listed for the namespace")
+		}
+	}
+
+	primaryPool := ipv4Pool
+	secondaryPool := ipv6Pool
+	if len(ipFamilies) > 0 && ipFamilies[0] == v1.IPv6Protocol {
+		primaryPool = ipv6Pool
+		secondaryPool = ipv4Pool
+	}
+	// Provide VIPs from both IP families if possible (guaranteed if RequireDualStack)
+	if len(primaryPool) > 0 {
+		primaryVip, err := discoverAddress(namespace, primaryPool, inUseIPSet, descOrder)
+		if err != nil {
+			return "", err
+		}
+		_, _ = vipBuilder.WriteString(primaryVip)
+	}
+	if len(secondaryPool) > 0 {
+		secondaryVip, err := discoverAddress(namespace, secondaryPool, inUseIPSet, descOrder)
+		if err != nil {
+			return "", err
+		}
+		if vipBuilder.Len() > 0 {
+			vipBuilder.WriteByte(',')
+		}
+		_, _ = vipBuilder.WriteString(secondaryVip)
+	}
+	return vipBuilder.String(), nil
 }
 
 func discoverAddress(namespace, pool string, inUseIPSet *netipx.IPSet, descOrder bool) (vip string, err error) {

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -439,6 +439,72 @@ func Test_discoverVIPs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "dualstack pool with PreferDualStack IPv4,IPv6 service, but the IPv6 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"fd00::1", "fd00::2"},
+			},
+			want:    "10.10.10.8",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv4,IPv6 service, but the IPv4 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9"},
+			},
+			want:    "fd00::1",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv6,IPv4 service, but the IPv6 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"fd00::1", "fd00::2"},
+			},
+			want:    "10.10.10.8",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv6,IPv4 service, but the IPv4 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9"},
+			},
+			want:    "fd00::1",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv4,IPv6 service, but no pools have available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9", "fd00::1", "fd00::2"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv4,IPv6 service, but there is an invalid pool",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2,invalid-pool",
+				existingServiceIPS: []string{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "IPv4 pool with RequireDualStack service",
 			args: args{
 				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
@@ -488,6 +554,61 @@ func Test_discoverVIPs(t *testing.T) {
 			want:    "fd00::1,10.10.10.8",
 			wantErr: false,
 		},
+		{
+			name: "dualstack pool with RequireDualStack IPv4,IPv6 service, but the IPv6 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"fd00::1", "fd00::2"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv4,IPv6 service, but the IPv4 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv6,IPv4 service, but the IPv6 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"fd00::1", "fd00::2"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv6,IPv4 service, but the IPv4 pool has no available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9"},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv4,IPv6 service, but no pools have available addresses",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.9,fd00::1-fd00::2",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9", "fd00::1", "fd00::2"},
+			},
+			want:    "",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -507,7 +628,7 @@ func Test_discoverVIPs(t *testing.T) {
 				return
 			}
 
-			gotString, err := discoverVIPs("unknown-namespace", tt.args.pool, s, false, tt.args.ipFamilyPolicy, tt.args.ipFamilies)
+			gotString, err := discoverVIPs("discover-vips-test-ns", tt.args.pool, s, false, tt.args.ipFamilyPolicy, tt.args.ipFamilies)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("discoverVIP() error: %v, expected: %v", err, tt.wantErr)
 				return

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -419,6 +419,15 @@ func Test_discoverVIPs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "dualstack pool with PreferDualStack service with no IP families explicitly specified",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				pool:           "10.10.10.8-10.10.10.15,fd00::1-fd00::10",
+			},
+			want:    "10.10.10.8,fd00::1",
+			wantErr: false,
+		},
+		{
 			name: "dualstack pool with PreferDualStack IPv4,IPv6 service",
 			args: args{
 				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -314,6 +314,212 @@ func Test_DiscoveryAddressRange(t *testing.T) {
 	}
 }
 
+func ipFamilyPolicyPtr(p v1.IPFamilyPolicy) *v1.IPFamilyPolicy {
+	return &p
+}
+
+func Test_discoverVIPs(t *testing.T) {
+	type args struct {
+		ipFamilyPolicy     *v1.IPFamilyPolicy
+		ipFamilies         []v1.IPFamily
+		pool               string
+		existingServiceIPS []string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "IPv4 pool",
+			args: args{
+				ipFamilyPolicy:     nil,
+				ipFamilies:         nil,
+				pool:               "10.10.10.8-10.10.10.15",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9", "10.10.10.10", "10.10.10.12"},
+			},
+			want:    "10.10.10.11",
+			wantErr: false,
+		},
+		{
+			name: "IPv4 pool with IPv4 service",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicySingleStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol},
+				pool:               "10.10.10.8-10.10.10.15",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9", "10.10.10.10", "10.10.10.12"},
+			},
+			want:    "10.10.10.11",
+			wantErr: false,
+		},
+		{
+			name: "IPv6 pool",
+			args: args{
+				ipFamilyPolicy:     nil,
+				ipFamilies:         nil,
+				pool:               "fd00::1-fd00::10",
+				existingServiceIPS: []string{"fd00::1", "fd00::2", "fd00::4"},
+			},
+			want:    "fd00::3",
+			wantErr: false,
+		},
+		{
+			name: "IPv6 pool with IPv6 service",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicySingleStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv6Protocol},
+				pool:               "fd00::1-fd00::10",
+				existingServiceIPS: []string{"fd00::1", "fd00::2", "fd00::4"},
+			},
+			want:    "fd00::3",
+			wantErr: false,
+		},
+		{
+			name: "IPv6 pool with IPv4 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicySingleStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol},
+				pool:           "fd00::1-fd00::10",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "IPv4 pool with IPv6 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicySingleStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv6Protocol},
+				pool:           "10.10.10.8-10.10.10.15",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "IPv4 pool with PreferDualStack service",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "10.10.10.8-10.10.10.15",
+				existingServiceIPS: []string{"10.10.10.8", "10.10.10.9", "10.10.10.10", "10.10.10.12"},
+			},
+			want:    "10.10.10.11",
+			wantErr: false,
+		},
+		{
+			name: "IPv6 pool with PreferDualStack service",
+			args: args{
+				ipFamilyPolicy:     ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:         []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:               "fd00::1-fd00::10",
+				existingServiceIPS: []string{"fd00::1", "fd00::2", "fd00::4"},
+			},
+			want:    "fd00::3",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv4,IPv6 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:           "10.10.10.8-10.10.10.15,fd00::1-fd00::10",
+			},
+			want:    "10.10.10.8,fd00::1",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with PreferDualStack IPv6,IPv4 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyPreferDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+				pool:           "10.10.10.8-10.10.10.15,fd00::1-fd00::10",
+			},
+			want:    "fd00::1,10.10.10.8",
+			wantErr: false,
+		},
+		{
+			name: "IPv4 pool with RequireDualStack service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:           "10.10.10.8-10.10.10.15",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "IPv6 pool with RequireDualStack service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:           "fd00::1-fd00::10",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "empty pool with RequireDualStack service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:           "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv4,IPv6 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol},
+				pool:           "10.10.10.8-10.10.10.15,fd00::1-fd00::10",
+			},
+			want:    "10.10.10.8,fd00::1",
+			wantErr: false,
+		},
+		{
+			name: "dualstack pool with RequireDualStack IPv6,IPv4 service",
+			args: args{
+				ipFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+				ipFamilies:     []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+				pool:           "10.10.10.8-10.10.10.15,fd00::1-fd00::10",
+			},
+			want:    "fd00::1,10.10.10.8",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &netipx.IPSetBuilder{}
+			for i := range tt.args.existingServiceIPS {
+				addr, err := netip.ParseAddr(tt.args.existingServiceIPS[i])
+				if err != nil {
+					t.Errorf("discoverVIP() error = %v", err)
+					return
+				}
+				builder.Add(addr)
+			}
+			s, err := builder.IPSet()
+			if err != nil {
+				t.Errorf("discoverVIP() error = %v", err)
+				return
+			}
+
+			gotString, err := discoverVIPs("unknown-namespace", tt.args.pool, s, false, tt.args.ipFamilyPolicy, tt.args.ipFamilies)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("discoverVIP() error: %v, expected: %v", err, tt.wantErr)
+				return
+			}
+			if !assert.EqualValues(t, tt.want, gotString) {
+				t.Errorf("discoverVIP() returned: %s, expected: %s", gotString, tt.want)
+			}
+		})
+	}
+
+}
+
 func Test_syncLoadBalancer(t *testing.T) {
 
 	tests := []struct {
@@ -483,6 +689,46 @@ func Test_syncLoadBalancer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "dualstack loadbalancer",
+			originalService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+				Spec: v1.ServiceSpec{
+					IPFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+					IPFamilies:     []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+				},
+			},
+
+			poolConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeVipClientConfig,
+					Namespace: KubeVipClientConfigNamespace,
+				},
+				Data: map[string]string{
+					"cidr-global": "10.120.120.1/24,fe80::10/126",
+				},
+			},
+			expectedService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+					Labels: map[string]string{
+						"implementation": "kube-vip",
+					},
+					Annotations: map[string]string{
+						"kube-vip.io/loadbalancerIPs": "fe80::10,10.120.120.1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					IPFamilyPolicy: ipFamilyPolicyPtr(v1.IPFamilyPolicyRequireDualStack),
+					IPFamilies:     []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol},
+					LoadBalancerIP: "fe80::10",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -529,7 +775,7 @@ func Test_syncLoadBalancer(t *testing.T) {
 				t.Error(err)
 			}
 
-			assert.EqualValues(t, *resService, tt.expectedService)
+			assert.EqualValues(t, tt.expectedService, *resService)
 		})
 	}
 }


### PR DESCRIPTION
As a follow-on to https://github.com/kube-vip/kube-vip/pull/687, I've decided to implement handling for dualstack loadbalancer services in kube-vip-cloud-provider by making the following changes:

- `kube-vip.io/loadbalancerIPs` may now contain multiple comma-separated IP addresses. This may be a breaking change without the PR from above
- Pools or ranges in the ConfigMap may now contain mixed IP families and they will be properly partitioned into a IPv4 bucket and an IPv6 bucket internally.
- kube-vip-cloud-provider now pays special attention to the ipFamilyPolicy field on the Service to determine if dualstack is preferred or required and assigns IPs according to the order specified in the ipFamilies field.

Any comments or concerns welcome!