### PR TITLE
fix: If the load balancing service does not have the annotation kube-…

### DIFF
--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -178,11 +178,13 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 
 	builder := &netipx.IPSetBuilder{}
 	for x := range svcs.Items {
-		addr, err := netip.ParseAddr(svcs.Items[x].Annotations[loadbalancerIPsAnnotations])
-		if err != nil {
-			return nil, err
+		if ip, ok := svcs.Items[x].Annotations[loadbalancerIPsAnnotations]; ok {
+			addr, err := netip.ParseAddr(ip)
+			if err != nil {
+				return nil, err
+			}
+			builder.Add(addr)
 		}
-		builder.Add(addr)
 	}
 	inUseSet, err := builder.IPSet()
 	if err != nil {


### PR DESCRIPTION
If the load balancing service does not have the annotation kube-vip.io/loadbalancerips, it will always be in a pending state
If the service lacks the annotation kube-vip.io/loadbalancerips, it will return null 
https://github.com/kube-vip/kube-vip-cloud-provider/blob/main/pkg/provider/loadBalancer.go#L181
The netip.ParseAddr method will return 'unable to parse IP'.


