### PR TITLE
Switch back to use kube-system as default namespace to look for confi…

### DIFF
--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -30,14 +30,14 @@ const (
 // kubevipLoadBalancerManager -
 type kubevipLoadBalancerManager struct {
 	kubeClient     kubernetes.Interface
-	nameSpace      string
+	namespace      string
 	cloudConfigMap string
 }
 
 func newLoadBalancer(kubeClient kubernetes.Interface, ns, cm string) cloudprovider.LoadBalancer {
 	k := &kubevipLoadBalancerManager{
 		kubeClient:     kubeClient,
-		nameSpace:      ns,
+		namespace:      ns,
 		cloudConfigMap: cm,
 	}
 	return k
@@ -145,11 +145,11 @@ func (k *kubevipLoadBalancerManager) syncLoadBalancer(ctx context.Context, servi
 	}
 
 	// Get the clound controller configuration map
-	controllerCM, err := k.GetConfigMap(ctx, k.cloudConfigMap, k.nameSpace)
+	controllerCM, err := k.GetConfigMap(ctx, k.cloudConfigMap, k.namespace)
 	if err != nil {
-		klog.Errorf("Unable to retrieve kube-vip ipam config from configMap [%s] in %s", k.cloudConfigMap, k.nameSpace)
+		klog.Errorf("Unable to retrieve kube-vip ipam config from configMap [%s] in %s", k.cloudConfigMap, k.namespace)
 		// TODO - determine best course of action, create one if it doesn't exist
-		controllerCM, err = k.CreateConfigMap(ctx, k.cloudConfigMap, k.nameSpace)
+		controllerCM, err = k.CreateConfigMap(ctx, k.cloudConfigMap, k.namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -864,7 +864,7 @@ func Test_syncLoadBalancer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ns := KubeVipClientConfigNamespace
-			cm := KubeVipCloudConfig
+			cm := KubeVipClientConfig
 			if tt.poolConfigMap != nil {
 				ns = tt.poolConfigMap.GetObjectMeta().GetNamespace()
 				cm = tt.poolConfigMap.GetObjectMeta().GetName()
@@ -872,7 +872,7 @@ func Test_syncLoadBalancer(t *testing.T) {
 
 			mgr := &kubevipLoadBalancerManager{
 				kubeClient:     fake.NewSimpleClientset(),
-				nameSpace:      ns,
+				namespace:      ns,
 				cloudConfigMap: cm,
 			}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 
 	cloudprovider "k8s.io/cloud-provider"
 )
@@ -21,9 +22,6 @@ var OutSideCluster bool
 const (
 	//ProviderName is the name of the cloud provider
 	ProviderName = "kubevip"
-
-	//KubeVipCloudConfig is the default name of the load balancer config Map
-	KubeVipCloudConfig = "kubevip"
 
 	//KubeVipClientConfig is the default name of the load balancer config Map
 	KubeVipClientConfig = "kubevip"
@@ -51,12 +49,14 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 	cm := os.Getenv("KUBEVIP_CONFIG_MAP")
 
 	if cm == "" {
-		cm = KubeVipCloudConfig
+		cm = KubeVipClientConfig
 	}
 
 	if ns == "" {
-		ns = "default"
+		ns = KubeVipClientConfigNamespace
 	}
+
+	klog.Infof("Watching configMap for pool config with name: '%s', namespace: '%s'", cm, ns)
 
 	var cl *kubernetes.Clientset
 	if !OutSideCluster {


### PR DESCRIPTION
…g map of pool

Fix https://github.com/kube-vip/kube-vip-cloud-provider/issues/87
This was reverted in https://github.com/kube-vip/kube-vip-cloud-provider/pull/63
Will  cut a new 0.0.9 release later

Tested
```
I0119 22:44:57.512025       1 provider.go:59] Watching configMap for pool config with name: 'kubevip', namespace: 'kube-system'
```