### PR TITLE
Update version to 0.0.9, and add arg to set version during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-ENV LD_FLAGS="-s -w -extldflags -static"
+ARG VERSION
+
+ENV LD_FLAGS="-s -w -extldflags -static -X k8s.io/component-base/version.gitVersion=$VERSION -s"
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \

--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,27 @@ TARGET := kube-vip-cloud-provider
 .DEFAULT_GOAL: $(TARGET)
 
 # These will be provided to the target
-VERSION := v0.0.7
+VERSION ?= v0.0.9
 BUILD := `git rev-parse HEAD`
 
 # Operating System Default (LINUX)
 TARGETOS=linux
 
 # Use linker flags to provide version/build settings to the target
-LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -s"
+LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -X k8s.io/component-base/version.gitVersion=$(VERSION) -s"
 
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-DOCKERTAG=$(VERSION)
-REPOSITORY=kubevip
+DOCKERTAG ?= $(VERSION)
+REPOSITORY ?= kubevip
 
 .PHONY: all build clean install uninstall fmt simplify check run
 
 all: check install
 
 $(TARGET): $(SRC)
+	@echo go build $(LDFLAGS) -o $(TARGET)
 	@go build $(LDFLAGS) -o $(TARGET)
 
 build: $(TARGET)
@@ -44,15 +45,15 @@ fmt:
 	@gofmt -l -w $(SRC)
 
 image-amd64-build-only:
-	@docker buildx build  --platform linux/amd64 -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@docker buildx build  --platform linux/amd64 --build-arg VERSION=$(VERSION) -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 
 # For faster local builds
 image-amd64:
-	@docker buildx build  --platform linux/amd64 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@docker buildx build  --platform linux/amd64  --build-arg VERSION=$(VERSION) --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
 image:
-	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
+	@docker buildx build  --platform linux/amd64,linux/arm64,linux/arm/v7 --build-arg VERSION=$(VERSION) --push -t $(REPOSITORY)/$(TARGET):$(DOCKERTAG) .
 	@echo New Multi Architecture Docker image created
 
 simplify:


### PR DESCRIPTION
Fix https://github.com/kube-vip/kube-vip-cloud-provider/issues/89
-X k8s.io/component-base/version.gitVersion=$(VERSION)  in go build so it could set version in log

Now example
```
I0119 23:29:26.520559       1 controllermanager.go:145] Version: v0.0.7
```