### PR TITLE
Add VERSION variable to publish and release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           username: kubevip
           password: ${{ secrets.DOCKERHUB_KUBEVIP_TOKEN }}
@@ -37,5 +37,7 @@ jobs:
             kubevip/kube-vip-cloud-provider:latest,
             ghcr.io/kube-vip/kube-vip-cloud-provider:${{ github.ref_name }},
             ghcr.io/kube-vip/kube-vip-cloud-provider:latest
+          build-args: |
+            VERSION=${{ github.ref_name }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 
 ARG VERSION
 
-ENV LD_FLAGS="-s -w -extldflags -static -X k8s.io/component-base/version.gitVersion=$VERSION -s"
+ENV LD_FLAGS="-s -w -extldflags -static -X k8s.io/component-base/version.gitVersion=$VERSION"
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \


### PR DESCRIPTION
Fix https://github.com/kube-vip/kube-vip-cloud-provider/issues/95
Now the build job is missing VERSION variable. Causing the image built by release job panic when running.

```
panic: version string "" doesn't match expected regular expression: "^v(\d+\.\d+\.\d+)" 
```


Now with the fix, the release job adds the version https://github.com/kube-vip/kube-vip-cloud-provider/actions/runs/7615359814/job/20739705540

```
#37 [linux/amd64 builder 5/5] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.local/share/golang     CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -extldflags -static -X k8s.io/component-base/version.gitVersion=v0.0.9-alpha" -o kube-vip-cloud-provider
```

And the dev image `ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.9-alpha` is deployed correctly 
```
 ~/work/src/github.com/lubronzhan/kube-vip-cloud-provider   topic/lubron/fix-95  kubectl logs -n kube-system kube-vip-cloud-provider-7d8f74c754-g2bh5
I0122 18:40:26.115334       1 serving.go:348] Generated self-signed cert in-memory
W0122 18:40:26.432979       1 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0122 18:40:26.433307       1 provider.go:59] Watching configMap for pool config with name: 'kubevip', namespace: 'kube-system'
I0122 18:40:26.433519       1 controllermanager.go:145] Version: v0.0.9-alpha
```
