### PR TITLE
Use go mod 1.22 way of range over integer syntax

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -155,8 +155,8 @@ func FindAvailableHostFromCidr(namespace, cidr string, inUseIPSet *netipx.IPSet,
 func FindFreeAddress(poolIPSet *netipx.IPSet, inUseIPSet *netipx.IPSet, descOrder bool) (netip.Addr, error) {
 	if descOrder {
 		ipranges := poolIPSet.Ranges()
-		for i := len(ipranges) - 1; i >= 0; i-- {
-			iprange := ipranges[i]
+		for i := range len(ipranges) - 1 {
+			iprange := ipranges[len(ipranges)-1-i]
 			ip := iprange.To()
 			for {
 				if !inUseIPSet.Contains(ip) && (!ip.Is4() || !isNetworkIDOrBroadcastIP(ip.As4())) {


### PR DESCRIPTION
Fix https://github.com/kube-vip/kube-vip-cloud-provider/issues/114