### PR TITLE
Update the deployment's default image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,4 +102,5 @@ e2e: | setup-kind-cluster load-kvcp-image-kind run-e2e cleanup-kind ## Run E2E t
 .PHONY: run-e2e
 run-e2e:
 	KUBE_VIP_CLOUD_PROVIDER_E2E_IMAGE=$(KUBE_VIP_CLOUD_PROVIDER_E2E_IMAGE) \
-	go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going -randomize-suites -randomize-all -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)
+	go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going  -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)
+#go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going -randomize-suites -randomize-all -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)

--- a/Makefile
+++ b/Makefile
@@ -102,5 +102,4 @@ e2e: | setup-kind-cluster load-kvcp-image-kind run-e2e cleanup-kind ## Run E2E t
 .PHONY: run-e2e
 run-e2e:
 	KUBE_VIP_CLOUD_PROVIDER_E2E_IMAGE=$(KUBE_VIP_CLOUD_PROVIDER_E2E_IMAGE) \
-	go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going  -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)
-#go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going -randomize-suites -randomize-all -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)
+	go run github.com/onsi/ginkgo/v2/ginkgo -tags=e2e -mod=readonly -keep-going -randomize-suites -randomize-all -poll-progress-after=120s --focus '$(KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS)' -r $(KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS)

--- a/test/e2e/defaultconfig/default_config_test.go
+++ b/test/e2e/defaultconfig/default_config_test.go
@@ -11,7 +11,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	tu "github.com/kube-vip/kube-vip-cloud-provider/pkg/testutil"
 	"github.com/kube-vip/kube-vip-cloud-provider/test/e2e"
@@ -26,7 +28,7 @@ func TestDeployWithDefaultConfig(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// By default, configMap only contains below 3 cidr
+	// By default, configMap only contains below 3 cidr:
 	// cidr-default: 192.168.0.200/29
 	// cidr-plunder: 192.168.0.210/29
 	// cidr-testing: 192.168.0.220/29
@@ -39,7 +41,7 @@ var _ = AfterSuite(func() {
 	require.NoError(f.T(), f.Deployment.DeleteResources())
 })
 
-var watchedNamespace = "testing"
+var watchedNamespaces = []string{"default", "testing", "plunder"}
 
 var _ = Describe("Default config", func() {
 	Context("Deploy service in namespace that kube-vip-cloud-provider is configured and is not configured", func() {
@@ -60,20 +62,33 @@ var _ = Describe("Default config", func() {
 					return !e2e.ServiceIsReconciled(svc) && !e2e.ServiceHasIPAssigned(svc)
 				}, 30*time.Second, time.Second, fmt.Sprintf("Service is not supposed to have label or annotation %v, with error %v", svc, err))
 
-				By("Create a service type LB in testing namespace")
-				svc = tu.NewService("test2", tu.TweakNamespace("watchedNamespace"))
-				_, err = f.Client.CoreV1().Services(svc.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
-				require.NoError(f.T(), err)
+				for _, ns := range watchedNamespaces {
+					By("Create a service type LB in watched namespace")
+					svc = tu.NewService(fmt.Sprintf("test-%s", ns), tu.TweakNamespace(ns))
+					_, err = f.Client.CoreV1().Services(svc.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
+					require.NoError(f.T(), err)
 
-				By("Service should have a valid IP assigned, and related kube-vip annotations and labels")
-				require.Eventually(f.T(), func() bool {
-					svc, err = f.Client.CoreV1().Services(svc.Namespace).Get(ctx, svc.Name, meta_v1.GetOptions{})
-					if err != nil {
+					By("Service should have a valid IP assigned, and related kube-vip annotations and labels")
+					require.Eventually(f.T(), func() bool {
+						svc, err = f.Client.CoreV1().Services(svc.Namespace).Get(ctx, svc.Name, meta_v1.GetOptions{})
+						if err != nil {
+							return false
+						}
+						return e2e.ServiceIsReconciled(svc) && e2e.ServiceHasIPAssigned(svc)
+					}, 30*time.Second, time.Second, fmt.Sprintf("Service is not successfully reconciled %v, with error %v", svc, err))
+
+					By("Clean up the service")
+					err := f.Client.CoreV1().Services(ns).Delete(context.TODO(), svc.Name,
+						meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+					require.Eventually(f.T(), func() bool {
+						svc, err = f.Client.CoreV1().Services(svc.Namespace).Get(ctx, svc.Name, meta_v1.GetOptions{})
+						if api_errors.IsNotFound(err) {
+							return true
+						}
 						return false
-					}
-					return e2e.ServiceIsReconciled(svc) && e2e.ServiceHasIPAssigned(svc)
-				}, 30*time.Second, time.Second, fmt.Sprintf("Service is not successfully reconciled %v, with error %v", svc, err))
+					}, 30*time.Second, time.Second, fmt.Sprintf("Service is not successfully deleted %v, with error %v", svc, err))
+				}
 			})
-		}, watchedNamespace)
+		}, watchedNamespaces[1:]...) // Don't delete default namespace.
 	})
 })

--- a/test/e2e/defaultconfig/default_config_test.go
+++ b/test/e2e/defaultconfig/default_config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Default config", func() {
 			Specify("Service should be reconciled, has ip assigned and correct label", func() {
 				ctx := context.TODO()
 				By("Create a service type LB")
-				svc := tu.NewService("test1", tu.TweakNamespace("default"))
+				svc := tu.NewService("svc-default", tu.TweakNamespace("default"))
 				_, err := f.Client.CoreV1().Services(svc.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
 				require.NoError(f.T(), err)
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -253,7 +253,7 @@ func (d *Deployment) DeleteResources() error {
 func (d *Deployment) DeleteServiceAccount() error {
 	// Common case of updating object if exists, create otherwise.
 	err := d.client.CoreV1().ServiceAccounts(d.ServiceAccount.Namespace).Delete(context.TODO(), d.ServiceAccount.Name,
-		*&meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+		meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}
@@ -281,7 +281,7 @@ func (d *Deployment) DeleteServiceAccount() error {
 func (d *Deployment) DeleteClusterRoleBinding() error {
 	// Common case of updating object if exists, create otherwise.
 	err := d.client.RbacV1().ClusterRoleBindings().Delete(context.TODO(), d.ClusterRoleBinding.Name,
-		*&meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+		meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}
@@ -306,7 +306,7 @@ func (d *Deployment) DeleteClusterRoleBinding() error {
 func (d *Deployment) DeleteClusterRole() error {
 	// Common case of updating object if exists, create otherwise.
 	err := d.client.RbacV1().ClusterRoles().Delete(context.TODO(), d.ClusterRole.Name,
-		*&meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+		meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}
@@ -334,7 +334,7 @@ func (d *Deployment) DeleteClusterRole() error {
 func (d *Deployment) DeleteConfigMap() error {
 	// Common case of updating object if exists, create otherwise.
 	err := d.client.CoreV1().ConfigMaps(d.ConfigMap.Namespace).Delete(context.TODO(), d.ConfigMap.Name,
-		*&meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+		meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}
@@ -362,7 +362,7 @@ func (d *Deployment) DeleteConfigMap() error {
 func (d *Deployment) DeleteDeployment() error {
 	// Common case of updating object if exists, create otherwise.
 	err := d.client.AppsV1().Deployments(d.Deployment.Namespace).Delete(context.TODO(), d.Deployment.Name,
-		*&meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
+		meta_v1.DeleteOptions{PropagationPolicy: ptr.To(meta_v1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -69,6 +69,9 @@ func NewFramework() *Framework {
 
 	require.NoError(t, deployment.UnmarshalResources())
 
+	// Update deployment's image
+	deployment.Deployment.Spec.Template.Spec.Containers[0].Image = kvcpImage
+
 	return &Framework{
 		Client:        client,
 		RetryInterval: time.Second,

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -71,6 +71,7 @@ func NewFramework() *Framework {
 
 	// Update deployment's image
 	deployment.Deployment.Spec.Template.Spec.Containers[0].Image = kvcpImage
+	deployment.Deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = core_v1.PullIfNotPresent
 
 	return &Framework{
 		Client:        client,


### PR DESCRIPTION
Now in e2e test, when deploying kube-vip-cloud-provider, by default it only use image inside manifest.yaml, it should be updated to whatever is generated in the e2e test.

Also the imagepullpolicy should be pullIfNotPresent

Also group the testsuite by kube-vip-cloud-provider configuration.