### PR TITLE
makefile: ensure that test-target is executed always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ KUBE_VIP_CLOUD_PROVIDER_E2E_IMAGE ?= ghcr.io/kube-vip/kube-vip-cloud-provider:ma
 KUBE_VIP_CLOUD_PROVIDER_E2E_TEST_FOCUS ?=
 KUBE_VIP_CLOUD_PROVIDER_E2E_PACKAGE_FOCUS ?= ./test/e2e
 
-.PHONY: all build clean install uninstall fmt simplify check run
+.PHONY: all build clean install uninstall fmt simplify check run test
 
 all: check install
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -155,7 +155,7 @@ func FindAvailableHostFromCidr(namespace, cidr string, inUseIPSet *netipx.IPSet,
 func FindFreeAddress(poolIPSet *netipx.IPSet, inUseIPSet *netipx.IPSet, descOrder bool) (netip.Addr, error) {
 	if descOrder {
 		ipranges := poolIPSet.Ranges()
-		for i := range len(ipranges) - 1 {
+		for i := range len(ipranges) {
 			iprange := ipranges[len(ipranges)-1-i]
 			ip := iprange.To()
 			for {


### PR DESCRIPTION
The recent actions of the "Build and Test" workflow did not execute the unittests anymore.
Output was only "(make: 'test' is up to date.)"
This commit adds "test" as phony target in make.
Solved a Bug in FindFreeAddress() introduced with 7b00941f6efb55edaacbc7d1c4befb63861aa75c