### PR TITLE
Added custom loadbalancerclass name option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Compiled tests from Ginkgo
 *.test
+kube-vip-cloud-provider

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The `kube-vip-cloud-provider` will only implement the `loadBalancer` functionali
 - Support assigning multiple services on single VIP (IPv4 only, optional)
 - Support specifying service interface per namespace or at global level
 - Support excluding first and last ip from cidr
+- Support custom loadbalancerClass name
 
 ## Installing the `kube-vip-cloud-provider`
 
@@ -142,6 +143,8 @@ Set the CIDR to `0.0.0.0/32`, that will make the controller to give all _LoadBal
 ## LoadbalancerClass support
 
 If users only want kube-vip-cloud-provider to allocate ip for specific set of services, they can pass `KUBEVIP_ENABLE_LOADBALANCERCLASS: true` as an environment variable to kube-vip-cloud-provider. kube-vip-cloud-provider will only allocate ip to service with `spec.loadBalancerClass: kube-vip.io/kube-vip-class`.
+
+If users want to use a custom loadbalancerClass name, they can pass `KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME: <custom name>` as an environment variable, with setting `KUBEVIP_ENABLE_LOADBALANCERCLASS: true`. They set `spec.loadBalancerClass: <custom name>` on the service.
 
 ## Allow multiple IPv4 services to share a VIP
 

--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -41,16 +41,18 @@ const (
 
 // kubevipLoadBalancerManager -
 type kubevipLoadBalancerManager struct {
-	kubeClient     kubernetes.Interface
-	namespace      string
-	cloudConfigMap string
+	kubeClient        kubernetes.Interface
+	namespace         string
+	cloudConfigMap    string
+	loadbalancerClass string
 }
 
-func newLoadBalancer(kubeClient kubernetes.Interface, ns, cm string) cloudprovider.LoadBalancer {
+func newLoadBalancer(kubeClient kubernetes.Interface, ns, cm string, lbClass string) cloudprovider.LoadBalancer {
 	k := &kubevipLoadBalancerManager{
-		kubeClient:     kubeClient,
-		namespace:      ns,
-		cloudConfigMap: cm,
+		kubeClient:        kubeClient,
+		namespace:         ns,
+		cloudConfigMap:    cm,
+		loadbalancerClass: lbClass,
 	}
 	return k
 }

--- a/pkg/provider/loadbalancerclass_test.go
+++ b/pkg/provider/loadbalancerclass_test.go
@@ -35,6 +35,7 @@ func newController(kubeClient *fake.Clientset) *loadbalancerClassServiceControll
 		kubeClient:          kubeClient,
 		cmName:              KubeVipClientConfig,
 		cmNamespace:         KubeVipClientConfigNamespace,
+		lbClass:             DefaultLoadbalancerClass,
 
 		recorder:  record.NewFakeRecorder(100),
 		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any](), "Nodes"),
@@ -64,30 +65,30 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 	}{
 		{
 			desc:              "udp service that wants LB",
-			service:           tu.NewService("udp-service", tu.TweakAddPorts(corev1.ProtocolUDP, 80, 0), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("udp-service", tu.TweakAddPorts(corev1.ProtocolUDP, 80, 0), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:              "tcp service that wants LB",
-			service:           tu.NewService("basic-service1", tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service1", tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:              "sctp service that wants LB",
-			service:           tu.NewService("sctp-service", tu.TweakAddPorts(corev1.ProtocolSCTP, 80, 0), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("sctp-service", tu.TweakAddPorts(corev1.ProtocolSCTP, 80, 0), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:             "service that needs cleanup",
-			service:          tu.NewService("basic-service2", tu.TweakAddLBIngress("8.8.8.8"), tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddDeletionTimestamp(time.Now()), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:          tu.NewService("basic-service2", tu.TweakAddLBIngress("8.8.8.8"), tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddDeletionTimestamp(time.Now()), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfPatch: 1,
 		},
 		{
 			desc:              "service with finalizer that wants LB",
-			service:           tu.NewService("basic-service3", tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service3", tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 		},
 	}
@@ -159,39 +160,39 @@ func TestSyncLoadBalancerIfNeededWithMultipleIpUse(t *testing.T) {
 	}{
 		{
 			desc:              "udp service that wants LB",
-			service:           tu.NewService("udp-service", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolUDP, 123, 123), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("udp-service", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolUDP, 123, 123), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectIP:          "10.0.0.2,2001::",
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:              "tcp service that wants LB",
-			service:           tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectIP:          "10.0.0.2,2001::1",
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:              "sctp service that wants LB",
-			service:           tu.NewService("sctp-service", tu.TweakAddPorts(corev1.ProtocolSCTP, 1234, 1234), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("sctp-service", tu.TweakAddPorts(corev1.ProtocolSCTP, 1234, 1234), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectIP:          "10.0.0.2",
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 		},
 		{
 			desc:             "service that needs cleanup",
-			service:          tu.NewService("basic-service2", tu.TweakAddLBIngress("8.8.8.8"), tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddDeletionTimestamp(time.Now()), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:          tu.NewService("basic-service2", tu.TweakAddLBIngress("8.8.8.8"), tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddDeletionTimestamp(time.Now()), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfPatch: 1,
 		},
 		{
 			desc:              "service with finalizer that wants LB",
-			service:           tu.NewService("basic-service3", tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service3", tu.TweakAddFinalizers(servicehelper.LoadBalancerCleanupFinalizer), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectIP:          "10.0.0.2",
 			expectNumOfUpdate: 1,
 		},
 		{
 			desc:              "now there is not enough ip, another tcp service that wants LB, but still could share ip with existing service",
-			service:           tu.NewService("basic-service4", tu.TweakAddPorts(corev1.ProtocolTCP, 8080, 8080), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service4", tu.TweakAddPorts(corev1.ProtocolTCP, 8080, 8080), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 			expectIP:          "10.0.0.2",
@@ -199,7 +200,7 @@ func TestSyncLoadBalancerIfNeededWithMultipleIpUse(t *testing.T) {
 		},
 		{
 			desc:              "another service who wants same port, get a new IP address",
-			service:           tu.NewService("basic-service5", tu.TweakAddPorts(corev1.ProtocolTCP, 80, 80), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:           tu.NewService("basic-service5", tu.TweakAddPorts(corev1.ProtocolTCP, 80, 80), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfUpdate: 1,
 			expectNumOfPatch:  1,
 			expectIP:          "10.0.0.3",
@@ -207,7 +208,7 @@ func TestSyncLoadBalancerIfNeededWithMultipleIpUse(t *testing.T) {
 		},
 		{
 			desc:             "another service who wants same port, no ip left, get no ip",
-			service:          tu.NewService("basic-service6", tu.TweakAddPorts(corev1.ProtocolTCP, 80, 80), tu.TweakAddLBClass(ptr.To(LoadbalancerClass))),
+			service:          tu.NewService("basic-service6", tu.TweakAddPorts(corev1.ProtocolTCP, 80, 80), tu.TweakAddLBClass(ptr.To(DefaultLoadbalancerClass))),
 			expectNumOfPatch: 1,
 			expectError:      true,
 		},
@@ -269,6 +270,7 @@ func TestNeedsUpdate(t *testing.T) {
 	testCases := []struct {
 		desc    string
 		service []*corev1.Service
+		lbClass string
 		expect  bool
 	}{
 		{
@@ -325,6 +327,36 @@ func TestNeedsUpdate(t *testing.T) {
 			client := fake.NewSimpleClientset()
 			c := newController(client)
 			nu := c.needsUpdate(tc.service[0], tc.service[1])
+			if tc.expect != nu {
+				t.Errorf("expect update to be %t, but get %t", tc.expect, nu)
+			}
+		})
+	}
+}
+
+func TestWantsLoadBalancer(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		service *corev1.Service
+		lbClass string
+		expect  bool
+	}{
+		{
+			desc: "service match load balancer class",
+			service: tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To("test-class"))),
+			lbClass: "test-class",
+			expect: true,
+		},
+		{
+			desc: "service mismatch load balancer class",
+			service: tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To("nok-class"))),
+			lbClass: "test-class",
+			expect: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nu := wantsLoadBalancer(tc.service, tc.lbClass)
 			if tc.expect != nu {
 				t.Errorf("expect update to be %t, but get %t", tc.expect, nu)
 			}

--- a/pkg/provider/loadbalancerclass_test.go
+++ b/pkg/provider/loadbalancerclass_test.go
@@ -342,16 +342,16 @@ func TestWantsLoadBalancer(t *testing.T) {
 		expect  bool
 	}{
 		{
-			desc: "service match load balancer class",
+			desc:    "service match load balancer class",
 			service: tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To("test-class"))),
 			lbClass: "test-class",
-			expect: true,
+			expect:  true,
 		},
 		{
-			desc: "service mismatch load balancer class",
+			desc:    "service mismatch load balancer class",
 			service: tu.NewService("basic-service1", tu.TweakDualStack(), tu.TweakAddPorts(corev1.ProtocolTCP, 345, 345), tu.TweakAddLBClass(ptr.To("nok-class"))),
 			lbClass: "test-class",
-			expect: false,
+			expect:  false,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -91,7 +91,11 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 	}
 	klog.Infof("starting with enable loadbalancerClass flag set to: %t", enableLBClass)
 
+	lbClass = DefaultLoadbalancerClass
 	if cbc != "" {
+		lbClass = cbc
+	}
+
 		lbClass = cbc
 	} else {
 		lbClass = DefaultLoadbalancerClass

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -95,11 +95,6 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 	if cbc != "" {
 		lbClass = cbc
 	}
-
-		lbClass = cbc
-	} else {
-		lbClass = DefaultLoadbalancerClass
-	}
 	klog.Infof("loadbalancerClass value set to: %s", lbClass)
 
 	klog.Infof("Watching configMap for pool config with name: '%s', namespace: '%s'", cm, ns)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -33,13 +33,18 @@ const (
 	// KubeVipServicesKey is the key in the ConfigMap that has the services configuration
 	KubeVipServicesKey = "kubevip-services"
 
-	// LoadbalancerClass is the value that could be set in service.spec.loadbalancerclass
-	// if the service has this value, then service controller will reconcile the service.
-	LoadbalancerClass = "kube-vip.io/kube-vip-class"
+	// CustomLoadbalancerClassEnvKey environment key for custom loadbalancerclass name.
+	// A LoadbalancerClass could be set in service.spec.loadbalancerclass. if the service has this value, 
+	// then service controller will reconcile the service
+	CustomLoadbalancerClassEnvKey = "KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME"
+
+	// DefaultLoadbalancerClass is the default loadbalancerClass name if no custom loadbalancerClass name is 
+	// supplied by CustomLoadbalancerClassEnvKey
+	DefaultLoadbalancerClass = "kube-vip.io/kube-vip-class"
 
 	// EnableLoadbalancerClassEnvKey environment key for enabling loadbalancerclass.
-	EnableLoadbalancerClassEnvKey = "KUBEVIP_ENABLE_LOADBALANCERCLASS"
-)
+	// This should be enabled if CustomLoadbalancerClassNameEnvKey is not empty
+	EnableLoadbalancerClassEnvKey = "KUBEVIP_ENABLE_LOADBALANCERCLASS")
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, newKubeVipCloudProvider)
@@ -52,6 +57,7 @@ type KubeVipCloudProvider struct {
 	namespace     string
 	configMapName string
 	enableLBClass bool
+	lbClass       string
 }
 
 var _ cloudprovider.Interface = &KubeVipCloudProvider{}
@@ -60,6 +66,7 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 	ns := os.Getenv("KUBEVIP_NAMESPACE")
 	cm := os.Getenv("KUBEVIP_CONFIG_MAP")
 	lbc := os.Getenv(EnableLoadbalancerClassEnvKey)
+	cbc := os.Getenv(CustomLoadbalancerClassEnvKey)
 
 	if cm == "" {
 		cm = KubeVipClientConfig
@@ -71,6 +78,7 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 
 	var (
 		enableLBClass bool
+		lbClass       string
 		err           error
 	)
 
@@ -81,7 +89,14 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 			return nil, fmt.Errorf("error parsing value of %s: %s", EnableLoadbalancerClassEnvKey, err.Error())
 		}
 	}
-	klog.Infof("staring with loadbalancerClass set to: %t", enableLBClass)
+	klog.Infof("starting with enable loadbalancerClass flag set to: %t", enableLBClass)
+
+	if cbc != "" {
+		lbClass = cbc
+	} else {
+		lbClass = DefaultLoadbalancerClass
+	}
+	klog.Infof("loadbalancerClass value set to: %s", lbClass)
 
 	klog.Infof("Watching configMap for pool config with name: '%s', namespace: '%s'", cm, ns)
 
@@ -108,11 +123,12 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 		}
 	}
 	return &KubeVipCloudProvider{
-		lb:            newLoadBalancer(cl, ns, cm),
+		lb:            newLoadBalancer(cl, ns, cm, lbClass),
 		kubeClient:    cl,
 		namespace:     ns,
 		configMapName: cm,
 		enableLBClass: enableLBClass,
+		lbClass:       lbClass,
 	}, nil
 }
 
@@ -124,9 +140,9 @@ func (p *KubeVipCloudProvider) Initialize(clientBuilder cloudprovider.Controller
 	sharedInformer := informers.NewSharedInformerFactory(clientset, 0)
 
 	if p.enableLBClass {
-		klog.Info("staring a separate service controller that only monitors service with loadbalancerClass")
+		klog.Info("starting a separate service controller that only monitors service with loadbalancerClass")
 		klog.Info("default cloud-provider service controller will ignore service with loadbalancerClass")
-		controller := newLoadbalancerClassServiceController(sharedInformer, p.kubeClient, p.configMapName, p.namespace)
+		controller := newLoadbalancerClassServiceController(sharedInformer, p.kubeClient, p.configMapName, p.namespace, p.lbClass)
 		go controller.Run(context.Background().Done())
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -34,17 +34,18 @@ const (
 	KubeVipServicesKey = "kubevip-services"
 
 	// CustomLoadbalancerClassEnvKey environment key for custom loadbalancerclass name.
-	// A LoadbalancerClass could be set in service.spec.loadbalancerclass. if the service has this value, 
-	// then service controller will reconcile the service
+	// A LoadbalancerClass could be set in service.spec.loadbalancerclass.
+	// If the service has this value, then service controller will reconcile the service.
 	CustomLoadbalancerClassEnvKey = "KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME"
 
-	// DefaultLoadbalancerClass is the default loadbalancerClass name if no custom loadbalancerClass name is 
+	// DefaultLoadbalancerClass is the default loadbalancerClass name if no custom loadbalancerClass name is
 	// supplied by CustomLoadbalancerClassEnvKey
 	DefaultLoadbalancerClass = "kube-vip.io/kube-vip-class"
 
 	// EnableLoadbalancerClassEnvKey environment key for enabling loadbalancerclass.
 	// This should be enabled if CustomLoadbalancerClassNameEnvKey is not empty
-	EnableLoadbalancerClassEnvKey = "KUBEVIP_ENABLE_LOADBALANCERCLASS")
+	EnableLoadbalancerClassEnvKey = "KUBEVIP_ENABLE_LOADBALANCERCLASS"
+)
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, newKubeVipCloudProvider)

--- a/test/e2e/loadbalancerclass/loadbalancerclass_test.go
+++ b/test/e2e/loadbalancerclass/loadbalancerclass_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Loadbalancerclass enabled", func() {
 			Specify("Service not be reconcile if namespace is not configured namespace testing, service in default namespace should be reconciled", func() {
 				ctx := context.TODO()
 				By("Create a service type LB in namespace that's not testing")
-				svc := tu.NewService("test1", tu.TweakNamespace(namespace), tu.TweakAddLBClass(ptr.To(provider.LoadbalancerClass)))
+				svc := tu.NewService("test1", tu.TweakNamespace(namespace), tu.TweakAddLBClass(ptr.To(provider.DefaultLoadbalancerClass)))
 				_, err := f.Client.CoreV1().Services(svc.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
 				require.NoError(f.T(), err)
 
@@ -77,7 +77,7 @@ var _ = Describe("Loadbalancerclass enabled", func() {
 
 				for _, ns := range watchedNamespaces {
 					By("Create a service type LB in watched namespace")
-					svc = tu.NewService(fmt.Sprintf("test-%s", ns), tu.TweakNamespace(ns), tu.TweakAddLBClass(ptr.To(provider.LoadbalancerClass)))
+					svc = tu.NewService(fmt.Sprintf("test-%s", ns), tu.TweakNamespace(ns), tu.TweakAddLBClass(ptr.To(provider.DefaultLoadbalancerClass)))
 					_, err = f.Client.CoreV1().Services(svc.Namespace).Create(ctx, svc, meta_v1.CreateOptions{})
 					require.NoError(f.T(), err)
 

--- a/test/e2e/loadbalancerclass/loadbalancerclass_test.go
+++ b/test/e2e/loadbalancerclass/loadbalancerclass_test.go
@@ -41,6 +41,10 @@ var _ = BeforeSuite(func() {
 			Name:  provider.EnableLoadbalancerClassEnvKey,
 			Value: "true",
 		},
+		core_v1.EnvVar{
+			Name:  provider.CustomLoadbalancerClassEnvKey,
+			Value: "kube-vip.io/custom-class",
+		},
 	)
 	require.NoError(f.T(), f.Deployment.EnsureResources())
 })


### PR DESCRIPTION
When the KUBEVIP_ENABLE_LOADBALANCERCLASS environment variable is enabled kube-vip-cloud-provider will only allocate ip to service with `spec.loadBalancerClass: kube-vip.io/kube-vip-class`
The KUBEVIP_CUSTOM_LOADBALANCERCLASS_NAME environment variable has been added to provide an option to override the default class name `kube-vip.io/kube-vip-class` to any other value.