### PR TITLE
Add github action to publish release note automatically

### DIFF
--- a/.github/workflows/generate-release-note.yml
+++ b/.github/workflows/generate-release-note.yml
@@ -1,0 +1,70 @@
+name: Generate Release Notes
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+  workflow_dispatch: # Use for manaully trigger to debug
+
+
+permissions:
+  contents: write # Allow to create a release.
+
+jobs:
+  generate-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Latest Release Tag
+        id: check
+        run: |
+          git fetch --tags --force
+          latest_tag=$(git tag --sort=-creatordate | head -n 1)
+          echo "latest release is ${latest_tag}"
+          echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+
+          ./hack/match-release-tag.sh ${latest_tag}
+          valid=$?
+          echo "valid=${valid}" >> $GITHUB_OUTPUT
+
+      - name: Find Second Latest Release Tag
+        if: ${{ steps.check.outputs.valid == '0' }}
+        id: find
+        run: |
+          SEMVER_REGEX='^[[:space:]]{0,}v[[:digit:]]{1,}\.[[:digit:]]{1,}\.[[:digit:]]{1,}(-(alpha|beta|rc)\.[[:digit:]]{1,}){0,1}[[:space:]]{0,}$'
+          PRERELEASE_SEMVER_REGEX='^v?[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$'
+          STABLE_RELEASE_SEMVER_REGEX='^v?[0-9]+\.[0-9]+\.[0-9]+$'
+
+          latest_tag=${{ steps.check.outputs.latest_tag }}
+
+          if [[ ${latest_tag} =~ ${PRERELEASE_SEMVER_REGEX} ]]; then
+            second_latest_release_tag=$(git tag --sort=-v:refname | grep -E ${SEMVER_REGEX} | awk "p{print; exit} /${latest_tag}/{p=1}")
+            echo "${latest_tag} is a pre-release, return second latest release tag ${second_latest_release_tag}"
+            echo "pre_release=1" >> $GITHUB_OUTPUT
+          else
+            second_latest_release_tag=$(git tag --sort=-v:refname | grep -E ${STABLE_RELEASE_SEMVER_REGEX} | awk "p{print; exit} /${latest_tag}/{p=1}")
+            echo "${latest_tag} is a stable release, return second stable release tag ${second_latest_release_tag}"
+            echo "pre_release=0" >> $GITHUB_OUTPUT
+          fi
+
+          echo "second_latest_release_tag=${second_latest_release_tag}" >> $GITHUB_OUTPUT
+
+      - name: Generate Pre Release Note
+        if: ${{ steps.check.outputs.valid == '0' && steps.find.outputs.pre_release == '1' }}
+        run: |
+          gh release create ${{ steps.check.outputs.latest_tag }} --verify-tag --generate-notes --notes-start-tag ${{ steps.find.outputs.second_latest_release_tag }} --prerelease
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Generate Release Note
+        if: ${{ steps.check.outputs.valid == '0' && steps.find.outputs.pre_release == '0' }}
+        run: |
+          gh release create ${{ steps.check.outputs.latest_tag }} --verify-tag --generate-notes --notes-start-tag ${{ steps.find.outputs.second_latest_release_tag }}
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/match-release-tag.sh
+++ b/match-release-tag.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat <<EOF
+usage: ${0} [TAG]
+  Verifies the provided tag is a release tag.
+
+TAG
+  If no tag is provided then "git describe --dirty" is used to obtain the tag.
+
+FLAGS
+  -h    prints this help screen
+  -x    run the examples
+EOF
+}
+
+while getopts ':hx' opt; do
+    case "${opt}" in
+        h)
+            usage 1>&2; exit 1
+        ;;
+        x)
+            EXAMPLES=1
+        ;;
+        \?)
+            { echo "invalid option: -${OPTARG}"; usage; } 1>&2; exit 1
+        ;;
+        :)
+            echo "option -${OPTARG} requires an argument" 1>&2; exit 1
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# The regular expression matches the following strings:
+#   * v1.0.0-alpha.0
+#   * v1.0.0-beta.0
+#   * v1.0.0-rc.0
+#   * v1.0.0
+# Any occurence of a digit in the above examples may be multiple digits.
+REGEX='^[[:space:]]{0,}v[[:digit:]]{1,}\.[[:digit:]]{1,}\.[[:digit:]]{1,}(-(alpha|beta|rc)\.[[:digit:]]{1,}){0,1}[[:space:]]{0,}$'
+
+# Match the tag against the regular expression for a release tag.
+match() {
+    if [[ ${1} =~ ${REGEX} ]]; then
+        echo "yay: ${1}"
+    else
+        exit_code="${?}"
+        echo "nay: ${1}"
+        return "${exit_code}"
+    fi
+}
+
+# Run examples to illustrate valid and invalid values.
+examples() {
+    local semvers=" \
+    v1.0.0-alpha.0 \
+    v1.0.0-beta.0 \
+    v1.0.0-rc.0 \
+    v1.0.0 \
+    v10.0.0 \
+    v1.10.0 \
+    v1.0.10 \
+    v10.0.0-alpha.10 \
+    v1.10.0-beta.10 \
+    v1.0.10-rc.10 \
+    1.0.0 \
+    v1.0.0+rc.0 \
+    v10a.0.0 \
+    1.1.0-alpha.1 \
+    v1.0.0-alpha.0a"
+    set +o errexit
+    for v in ${semvers}; do match "${v}"; done
+    return 0
+}
+
+main() {
+    # Get the tag from the remaining arguments or from "git describe --dirty"
+    [ "${#}" -eq "0" ] || tag="${1}"
+    [ -n "${tag-}" ] || tag="$(git describe --dirty)"
+    
+    # Match the tag against the regular expression for a release tag.
+    match "${tag}" 1>&2
+}
+
+{ [ "${EXAMPLES-}" ] && examples; } || main "${@-}"


### PR DESCRIPTION
1. Checks whether new tag is valid or not (vx.x.x)
2. Find the second latest tag and use it as a comparison to generate note
