### PR TITLE
fix: ignore classed services in default controller

### DIFF
--- a/pkg/provider/loadBalancer.go
+++ b/pkg/provider/loadBalancer.go
@@ -44,25 +44,27 @@ type kubevipLoadBalancerManager struct {
 	kubeClient        kubernetes.Interface
 	namespace         string
 	cloudConfigMap    string
+	enableLBClass     bool
 	loadbalancerClass string
 }
 
-func newLoadBalancer(kubeClient kubernetes.Interface, ns, cm string, lbClass string) cloudprovider.LoadBalancer {
+func newLoadBalancer(kubeClient kubernetes.Interface, ns, cm string, enableLBClass bool, lbClass string) cloudprovider.LoadBalancer {
 	k := &kubevipLoadBalancerManager{
 		kubeClient:        kubeClient,
 		namespace:         ns,
 		cloudConfigMap:    cm,
+		enableLBClass:     enableLBClass,
 		loadbalancerClass: lbClass,
 	}
 	return k
 }
 
 func (k *kubevipLoadBalancerManager) EnsureLoadBalancer(ctx context.Context, _ string, service *v1.Service, _ []*v1.Node) (lbs *v1.LoadBalancerStatus, err error) {
-	return syncLoadBalancer(ctx, k.kubeClient, service, k.cloudConfigMap, k.namespace)
+	return syncLoadBalancer(ctx, k.kubeClient, service, k.cloudConfigMap, k.namespace, k.enableLBClass, k.loadbalancerClass)
 }
 
 func (k *kubevipLoadBalancerManager) UpdateLoadBalancer(ctx context.Context, _ string, service *v1.Service, _ []*v1.Node) (err error) {
-	_, err = syncLoadBalancer(ctx, k.kubeClient, service, k.cloudConfigMap, k.namespace)
+	_, err = syncLoadBalancer(ctx, k.kubeClient, service, k.cloudConfigMap, k.namespace, k.enableLBClass, k.loadbalancerClass)
 	return err
 }
 
@@ -71,6 +73,10 @@ func (k *kubevipLoadBalancerManager) EnsureLoadBalancerDeleted(ctx context.Conte
 }
 
 func (k *kubevipLoadBalancerManager) GetLoadBalancer(_ context.Context, _ string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	if !matchLoadBalancerClass(service, k.enableLBClass, k.loadbalancerClass) {
+		return nil, false, nil
+	}
+
 	if service.Labels[ImplementationLabelKey] == ImplementationLabelValue {
 		return &service.Status.LoadBalancer, true, nil
 	}
@@ -91,6 +97,14 @@ func (k *kubevipLoadBalancerManager) deleteLoadBalancer(_ context.Context, servi
 	klog.Infof("deleting service '%s' (%s)", service.Name, service.UID)
 
 	return nil
+}
+
+func matchLoadBalancerClass(service *v1.Service, enableLBClass bool, lbClass string) bool {
+	if !enableLBClass {
+		return true
+	}
+
+	return service.Spec.LoadBalancerClass != nil && *service.Spec.LoadBalancerClass == lbClass
 }
 
 func checkLegacyLoadBalancerIPAnnotation(ctx context.Context, kubeClient kubernetes.Interface, service *v1.Service) (*v1.LoadBalancerStatus, error) {
@@ -194,15 +208,29 @@ func mapImplementedServices(svcs *v1.ServiceList, allowShare bool) (inUseSet *ne
 	return inUseSet, servicePortMap, nil
 }
 
-// syncLoadBalancer
+// syncLoadBalancer reconciles the load balancer state
 // 1. Is this loadBalancer already created, and does it have an address? return status
 // 2. Is this a new loadBalancer (with no IP address)
 // 2a. Get all existing kube-vip services
 // 2b. Get the network configuration for this service (namespace) / (CIDR/Range)
 // 2c. Between the two find a free address
 
-func syncLoadBalancer(ctx context.Context, kubeClient kubernetes.Interface, service *v1.Service, cmName, cmNamespace string) (*v1.LoadBalancerStatus, error) {
-	// This function reconciles the load balancer state
+func syncLoadBalancer(ctx context.Context, kubeClient kubernetes.Interface, service *v1.Service, cmName, cmNamespace string,
+	enableLBClass bool, lbClass string) (*v1.LoadBalancerStatus, error) {
+
+	if !matchLoadBalancerClass(service, enableLBClass, lbClass) {
+		var serviceClass string
+		if service.Spec.LoadBalancerClass != nil {
+			serviceClass = *service.Spec.LoadBalancerClass
+		} else {
+			serviceClass = "<nil>"
+		}
+		klog.V(4).Infof("skipping service %s/%s, service class %q doesn't match configured loadbalancerClass %q",
+			service.Namespace, service.Name, serviceClass, lbClass)
+
+		return &service.Status.LoadBalancer, nil
+	}
+
 	klog.Infof("syncing service '%s' (%s)", service.Name, service.UID)
 
 	// The loadBalancer address has already been populated

--- a/pkg/provider/loadBalancer_test.go
+++ b/pkg/provider/loadBalancer_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 func Test_DiscoveryPoolCIDR(t *testing.T) {
@@ -714,6 +715,8 @@ func Test_syncLoadBalancer(t *testing.T) {
 		originalService v1.Service
 		poolConfigMap   *v1.ConfigMap
 		expectedService v1.Service
+		enableLBClass   bool
+		lbClass         string
 		wantErr         bool
 	}{
 		{
@@ -1020,6 +1023,85 @@ func Test_syncLoadBalancer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "service with matching loadbalancerClass is reconciled",
+			originalService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerClass: ptr.To(DefaultLoadbalancerClass),
+				},
+			},
+			poolConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      KubeVipClientConfig,
+					Namespace: KubeVipClientConfigNamespace,
+				},
+				Data: map[string]string{
+					"cidr-global": "192.168.1.1/24",
+				},
+			},
+			expectedService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+					Labels: map[string]string{
+						"implementation": "kube-vip",
+					},
+					Annotations: map[string]string{
+						LoadbalancerIPsAnnotation: "192.168.1.1",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerClass: ptr.To(DefaultLoadbalancerClass),
+					LoadBalancerIP:    "192.168.1.1",
+				},
+			},
+			enableLBClass: true,
+			lbClass:       DefaultLoadbalancerClass,
+		},
+		{
+			name: "service with different loadbalancerClass is ignored",
+			originalService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerClass: ptr.To("custom-class"),
+				},
+			},
+			expectedService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerClass: ptr.To("custom-class"),
+				},
+			},
+			enableLBClass: true,
+			lbClass:       DefaultLoadbalancerClass,
+		},
+		{
+			name: "classless service is ignored when loadbalancerClass is enabled",
+			originalService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+			},
+			expectedService: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "name",
+				},
+			},
+			enableLBClass: true,
+			lbClass:       DefaultLoadbalancerClass,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1051,7 +1133,7 @@ func Test_syncLoadBalancer(t *testing.T) {
 				}
 			}
 
-			_, err = syncLoadBalancer(context.Background(), mgr.kubeClient, &tt.originalService, cm, ns) // #nosec G601
+			_, err = syncLoadBalancer(context.Background(), mgr.kubeClient, &tt.originalService, cm, ns, tt.enableLBClass, tt.lbClass) // #nosec G601
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/provider/loadbalancerclass.go
+++ b/pkg/provider/loadbalancerclass.go
@@ -211,7 +211,7 @@ func (c *loadbalancerClassServiceController) processServiceCreateOrUpdate(svc *c
 		return err
 	}
 
-	if _, err := syncLoadBalancer(context.Background(), c.kubeClient, svc, c.cmName, c.cmNamespace); err != nil {
+	if _, err := syncLoadBalancer(context.Background(), c.kubeClient, svc, c.cmName, c.cmNamespace, true, c.lbClass); err != nil {
 		c.recorder.Eventf(svc, corev1.EventTypeWarning, "syncLoadBalancer", "Error syncing load balancer: %v", err)
 		return err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -123,7 +123,7 @@ func newKubeVipCloudProvider(io.Reader) (cloudprovider.Interface, error) {
 		}
 	}
 	return &KubeVipCloudProvider{
-		lb:            newLoadBalancer(cl, ns, cm, lbClass),
+		lb:            newLoadBalancer(cl, ns, cm, enableLBClass, lbClass),
 		kubeClient:    cl,
 		namespace:     ns,
 		configMapName: cm,


### PR DESCRIPTION
When running a default `kube-vip-cloud-provider` alongside a class-specific instance, the default controller also reconciles Services with `spec.loadBalancerClass` set, causing both controllers to compete for the same Service.

This change makes the default controller ignore Services with a non-empty `spec.loadBalancerClass`, leaving them to class-specific controllers.

This preserves the existing behavior for classless LoadBalancer Services while allowing multiple CCM instances to coexist safely.

Fixes #301